### PR TITLE
refactor: Rename to `graphql-ws`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-# [1.9.0](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
+# [1.9.1](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
 
 
 ### Features
 
 * Package rename `graphql-transport-ws` 👉 `graphql-ws`. ([#43](https://github.com/enisdenjo/graphql-ws/pull/43))
+
+# [1.9.0](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
+
+
+### Features
 
 * **server:** More callbacks, clearer differences and higher extensibility ([#40](https://github.com/enisdenjo/graphql-ws/issues/40)) ([507a222](https://github.com/enisdenjo/graphql-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-# [1.9.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
+# [1.9.0](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
 
 
 ### Features
 
-* **server:** More callbacks, clearer differences and higher extensibility ([#40](https://github.com/enisdenjo/graphql-transport-ws/issues/40)) ([507a222](https://github.com/enisdenjo/graphql-transport-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3))
+* **server:** More callbacks, clearer differences and higher extensibility ([#40](https://github.com/enisdenjo/graphql-ws/issues/40)) ([507a222](https://github.com/enisdenjo/graphql-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3))
 
 
 ### BREAKING CHANGES
 
-_Should've been a major release but `semantic-release` didn't detect the breaking changes of the [507a222](https://github.com/enisdenjo/graphql-transport-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3) commit, so here we are..._
+_Should've been a major release but `semantic-release` didn't detect the breaking changes of the [507a222](https://github.com/enisdenjo/graphql-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3) commit, so here we are..._
 
 This time we come with a few breaking changes that will open doors for all sorts of enhancements. Check the linked PR for more details.
 
@@ -26,155 +26,155 @@ Dropped in favour of applying custom validation rules in the `onSubscribe` callb
 #### Server option `formatExecutionResult`
 Dropped in favour of using the return value of `onNext` callback.
 
-## [1.8.2](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.8.1...v1.8.2) (2020-10-22)
+## [1.8.2](https://github.com/enisdenjo/graphql-ws/compare/v1.8.1...v1.8.2) (2020-10-22)
 
 
 ### Bug Fixes
 
-* **server:** No need to bind `this` scope ([f76ac73](https://github.com/enisdenjo/graphql-transport-ws/commit/f76ac73e9d21c80abe0118007e168e4f5d525036))
+* **server:** No need to bind `this` scope ([f76ac73](https://github.com/enisdenjo/graphql-ws/commit/f76ac73e9d21c80abe0118007e168e4f5d525036))
 
-## [1.8.1](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.8.0...v1.8.1) (2020-10-22)
+## [1.8.1](https://github.com/enisdenjo/graphql-ws/compare/v1.8.0...v1.8.1) (2020-10-22)
 
 
 ### Bug Fixes
 
-* yarn engine is not required ([#34](https://github.com/enisdenjo/graphql-transport-ws/issues/34)) ([89484b8](https://github.com/enisdenjo/graphql-transport-ws/commit/89484b89d6f561d0eb43d64e8c1ee568bcfebcd6))
-* **server:** Hide internal server error messages from the client in production ([36fe405](https://github.com/enisdenjo/graphql-transport-ws/commit/36fe405e0e7d5942f858073797cc85bb41739a1d)), closes [#31](https://github.com/enisdenjo/graphql-transport-ws/issues/31)
+* yarn engine is not required ([#34](https://github.com/enisdenjo/graphql-ws/issues/34)) ([89484b8](https://github.com/enisdenjo/graphql-ws/commit/89484b89d6f561d0eb43d64e8c1ee568bcfebcd6))
+* **server:** Hide internal server error messages from the client in production ([36fe405](https://github.com/enisdenjo/graphql-ws/commit/36fe405e0e7d5942f858073797cc85bb41739a1d)), closes [#31](https://github.com/enisdenjo/graphql-ws/issues/31)
 
-# [1.8.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.7.0...v1.8.0) (2020-10-19)
+# [1.8.0](https://github.com/enisdenjo/graphql-ws/compare/v1.7.0...v1.8.0) (2020-10-19)
 
 
 ### Features
 
-* **server:** Support returning multiple results from `execute` ([#28](https://github.com/enisdenjo/graphql-transport-ws/issues/28)) ([dbbd88b](https://github.com/enisdenjo/graphql-transport-ws/commit/dbbd88bb26843da55d9558e7a44bff3108f095ab))
+* **server:** Support returning multiple results from `execute` ([#28](https://github.com/enisdenjo/graphql-ws/issues/28)) ([dbbd88b](https://github.com/enisdenjo/graphql-ws/commit/dbbd88bb26843da55d9558e7a44bff3108f095ab))
 
-# [1.7.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.6.0...v1.7.0) (2020-10-01)
-
-
-### Bug Fixes
-
-* **client:** Dispose of subscription on complete or error messages ([#23](https://github.com/enisdenjo/graphql-transport-ws/issues/23)) ([fb4d8e9](https://github.com/enisdenjo/graphql-transport-ws/commit/fb4d8e9efdfdd0cbe3b7cc34ddadbad3a795ae35))
-* **server:** `subscription` operations are distinct on the message ID ([#24](https://github.com/enisdenjo/graphql-transport-ws/issues/24)) ([dfffb05](https://github.com/enisdenjo/graphql-transport-ws/commit/dfffb0502be5dd9ab5598e785b9988b1f4000227))
-
-
-### Features
-
-* **client:** Optional `generateID` to provide subscription IDs ([#22](https://github.com/enisdenjo/graphql-transport-ws/issues/22)) ([9a3f54a](https://github.com/enisdenjo/graphql-transport-ws/commit/9a3f54a8198379b402a8abe414ab5727ccec45cf)), closes [#21](https://github.com/enisdenjo/graphql-transport-ws/issues/21)
-
-# [1.6.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.5.0...v1.6.0) (2020-09-28)
-
-
-### Features
-
-* **client:** Support providing custom WebSocket implementations ([#18](https://github.com/enisdenjo/graphql-transport-ws/issues/18)) ([1515fe2](https://github.com/enisdenjo/graphql-transport-ws/commit/1515fe2adcc0bb2b18a1309550f4e41528985f54))
-
-# [1.5.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.4.2...v1.5.0) (2020-09-18)
+# [1.7.0](https://github.com/enisdenjo/graphql-ws/compare/v1.6.0...v1.7.0) (2020-10-01)
 
 
 ### Bug Fixes
 
-* **server:** Use `subscribe` from the config ([6fbd47c](https://github.com/enisdenjo/graphql-transport-ws/commit/6fbd47c2ef14a6ae4297ffe0aaa689eeb3741ed0))
+* **client:** Dispose of subscription on complete or error messages ([#23](https://github.com/enisdenjo/graphql-ws/issues/23)) ([fb4d8e9](https://github.com/enisdenjo/graphql-ws/commit/fb4d8e9efdfdd0cbe3b7cc34ddadbad3a795ae35))
+* **server:** `subscription` operations are distinct on the message ID ([#24](https://github.com/enisdenjo/graphql-ws/issues/24)) ([dfffb05](https://github.com/enisdenjo/graphql-ws/commit/dfffb0502be5dd9ab5598e785b9988b1f4000227))
 
 
 ### Features
 
-* **server:** Define execution/subscription `context` in creation options ([5b3d253](https://github.com/enisdenjo/graphql-transport-ws/commit/5b3d25351cdd2714a1edb9833ab2c2c7a9316944)), closes [#13](https://github.com/enisdenjo/graphql-transport-ws/issues/13)
+* **client:** Optional `generateID` to provide subscription IDs ([#22](https://github.com/enisdenjo/graphql-ws/issues/22)) ([9a3f54a](https://github.com/enisdenjo/graphql-ws/commit/9a3f54a8198379b402a8abe414ab5727ccec45cf)), closes [#21](https://github.com/enisdenjo/graphql-ws/issues/21)
 
-## [1.4.2](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.4.1...v1.4.2) (2020-09-16)
+# [1.6.0](https://github.com/enisdenjo/graphql-ws/compare/v1.5.0...v1.6.0) (2020-09-28)
+
+
+### Features
+
+* **client:** Support providing custom WebSocket implementations ([#18](https://github.com/enisdenjo/graphql-ws/issues/18)) ([1515fe2](https://github.com/enisdenjo/graphql-ws/commit/1515fe2adcc0bb2b18a1309550f4e41528985f54))
+
+# [1.5.0](https://github.com/enisdenjo/graphql-ws/compare/v1.4.2...v1.5.0) (2020-09-18)
 
 
 ### Bug Fixes
 
-* **server:** Receiving more than one `ConnectionInit` message closes the socket immediately ([757c6e9](https://github.com/enisdenjo/graphql-transport-ws/commit/757c6e966ffa1756cca2687b0275d7d7eff2ce87))
+* **server:** Use `subscribe` from the config ([6fbd47c](https://github.com/enisdenjo/graphql-ws/commit/6fbd47c2ef14a6ae4297ffe0aaa689eeb3741ed0))
 
-## [1.4.1](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.4.0...v1.4.1) (2020-09-11)
+
+### Features
+
+* **server:** Define execution/subscription `context` in creation options ([5b3d253](https://github.com/enisdenjo/graphql-ws/commit/5b3d25351cdd2714a1edb9833ab2c2c7a9316944)), closes [#13](https://github.com/enisdenjo/graphql-ws/issues/13)
+
+## [1.4.2](https://github.com/enisdenjo/graphql-ws/compare/v1.4.1...v1.4.2) (2020-09-16)
+
+
+### Bug Fixes
+
+* **server:** Receiving more than one `ConnectionInit` message closes the socket immediately ([757c6e9](https://github.com/enisdenjo/graphql-ws/commit/757c6e966ffa1756cca2687b0275d7d7eff2ce87))
+
+## [1.4.1](https://github.com/enisdenjo/graphql-ws/compare/v1.4.0...v1.4.1) (2020-09-11)
 
 
 ### Performance Improvements
 
-* **client:** Memoize message parsing for each subscriber ([2a7ba46](https://github.com/enisdenjo/graphql-transport-ws/commit/2a7ba4642c0ea1a3294b8b3ea3440957ec7fcb7b))
+* **client:** Memoize message parsing for each subscriber ([2a7ba46](https://github.com/enisdenjo/graphql-ws/commit/2a7ba4642c0ea1a3294b8b3ea3440957ec7fcb7b))
 
-# [1.4.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.3.0...v1.4.0) (2020-09-10)
-
-
-### Bug Fixes
-
-* **client:** Only `query` is required in the subscribe payload ([e892530](https://github.com/enisdenjo/graphql-transport-ws/commit/e892530b37108a210976e416b2f5eb3004be7ad3))
-
-
-### Features
-
-* **server:** Pass roots for operation fields as an option ([dcb5ed4](https://github.com/enisdenjo/graphql-transport-ws/commit/dcb5ed4dcc3c4569b104b2cbe9979161fad2ff0a))
-
-# [1.3.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.2.0...v1.3.0) (2020-09-10)
-
-
-### Features
-
-* WebSocket Ping and Pong as keep-alive ([#11](https://github.com/enisdenjo/graphql-transport-ws/issues/11)) ([16ae316](https://github.com/enisdenjo/graphql-transport-ws/commit/16ae316b35a90d45f379336ec3ed5bedf3f2e28e))
-* **client:** Emit events for `connecting`, `connected` and `closed` ([627775b](https://github.com/enisdenjo/graphql-transport-ws/commit/627775b8e1aca8f359607020ff2c3bcc37b50787))
-* **client:** Implement silent-reconnects ([c6f7872](https://github.com/enisdenjo/graphql-transport-ws/commit/c6f7872126300befcc47e8e46e82342c2924f453)), closes [#7](https://github.com/enisdenjo/graphql-transport-ws/issues/7)
-* **client:** Lazy option can be changed ([fb0ec14](https://github.com/enisdenjo/graphql-transport-ws/commit/fb0ec1478e5219eb75e6bf2a1c2fd2a3a9cbb90d))
-
-# [1.2.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.1.1...v1.2.0) (2020-09-04)
-
-
-### Features
-
-* Package rename `@enisdenjo/graphql-transport-ws` 👉 `graphql-transport-ws`. ([494f676](https://github.com/enisdenjo/graphql-transport-ws/commit/494f6766279325769e81f52ce7b4b442c85f9476))
-
-## [1.1.1](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.1.0...v1.1.1) (2020-08-28)
+# [1.4.0](https://github.com/enisdenjo/graphql-ws/compare/v1.3.0...v1.4.0) (2020-09-10)
 
 
 ### Bug Fixes
 
-* add the sink to the subscribed map AFTER emitting a subscribe message ([814f46c](https://github.com/enisdenjo/graphql-transport-ws/commit/814f46c119792aaa240d0fcdb318dccdd1cc0e87))
-* notify only relevant sinks about errors or completions ([62155ba](https://github.com/enisdenjo/graphql-transport-ws/commit/62155ba0b79516141633b86765921b2401fcc2ed))
-
-# [1.1.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.0.2...v1.1.0) (2020-08-28)
-
-
-### Bug Fixes
-
-* **server:** allow skipping init message wait with zero values ([a7419df](https://github.com/enisdenjo/graphql-transport-ws/commit/a7419df077acb018418016c7a06716fb3c054ddb))
-* **server:** use subscription specific formatter for queries and mutations too ([5672a04](https://github.com/enisdenjo/graphql-transport-ws/commit/5672a045332ea835e6ff7ce862c7c2a46729363b))
+* **client:** Only `query` is required in the subscribe payload ([e892530](https://github.com/enisdenjo/graphql-ws/commit/e892530b37108a210976e416b2f5eb3004be7ad3))
 
 
 ### Features
 
-* **client:** introduce Socky 🧦 - the nifty internal socket state manager ([#8](https://github.com/enisdenjo/graphql-transport-ws/issues/8)) ([a4bee6f](https://github.com/enisdenjo/graphql-transport-ws/commit/a4bee6fb8c1bd56637363a76f6ab0c3b64f55931))
+* **server:** Pass roots for operation fields as an option ([dcb5ed4](https://github.com/enisdenjo/graphql-ws/commit/dcb5ed4dcc3c4569b104b2cbe9979161fad2ff0a))
 
-## [1.0.2](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.0.1...v1.0.2) (2020-08-26)
-
-
-### Bug Fixes
-
-* correctly detect WebSocket server ([eab29dc](https://github.com/enisdenjo/graphql-transport-ws/commit/eab29dcae3d031a117de37dee09770833e9573cf))
-
-## [1.0.1](https://github.com/enisdenjo/graphql-transport-ws/compare/v1.0.0...v1.0.1) (2020-08-26)
-
-
-### Bug Fixes
-
-* reset connected/connecting state when disconnecting and disposing ([2eb3cd5](https://github.com/enisdenjo/graphql-transport-ws/commit/2eb3cd5965cf34f6d6b21748daea520163b9c789))
-* **client:** cant read the `CloseEvent.reason` after bundling so just pass the whole event to the sink error and let the user handle it ([9ccb46b](https://github.com/enisdenjo/graphql-transport-ws/commit/9ccb46bc80024cb2de823702d2bd308052c6c516))
-* **client:** send complete message and close only if socket is still open ([49b75ce](https://github.com/enisdenjo/graphql-transport-ws/commit/49b75cec60fec9c8a42119b124a9c54d29d30308))
-* http and ws have no default exports ([5c01ed9](https://github.com/enisdenjo/graphql-transport-ws/commit/5c01ed924793ce17f036d26d9d5d63cd5cecc6aa))
-* include `types` file holding important types ([f3e4edf](https://github.com/enisdenjo/graphql-transport-ws/commit/f3e4edf96e5c6cecf025811e2beb7ecc324ea962))
-* **server:** scoped execution result formatter from `onConnect` ([f91fadb](https://github.com/enisdenjo/graphql-transport-ws/commit/f91fadb6464a6e74f9a11555026dd5f9279df563))
-* export both the client and the server from index ([29923b1](https://github.com/enisdenjo/graphql-transport-ws/commit/29923b1e35a462c5b5a19d64603d59f25c1c5987))
-* **server:** store the intial request in the context ([6927ee0](https://github.com/enisdenjo/graphql-transport-ws/commit/6927ee01c0b8224f8290322a964e70382614d0e8))
-
-# [1.0.0](https://github.com/enisdenjo/graphql-transport-ws/compare/v0.0.2...v1.0.0) (2020-08-17)
+# [1.3.0](https://github.com/enisdenjo/graphql-ws/compare/v1.2.0...v1.3.0) (2020-09-10)
 
 
 ### Features
 
-* **client:** Re-implement following the new transport protocol ([#6](https://github.com/enisdenjo/graphql-transport-ws/issues/6)) ([5191a35](https://github.com/enisdenjo/graphql-transport-ws/commit/5191a358098c6f9a661ae90e0420fa430db9152c))
-* **server:** Implement following the new transport protocol ([#1](https://github.com/enisdenjo/graphql-transport-ws/issues/1)) ([a412d25](https://github.com/enisdenjo/graphql-transport-ws/commit/a412d2570e484046a058c11f39813c7794ec9147))
-* Rewrite GraphQL over WebSocket Protocol ([#2](https://github.com/enisdenjo/graphql-transport-ws/issues/2)) ([42045c5](https://github.com/enisdenjo/graphql-transport-ws/commit/42045c577de9d95a81a37d850b38f4482914cebd))
+* WebSocket Ping and Pong as keep-alive ([#11](https://github.com/enisdenjo/graphql-ws/issues/11)) ([16ae316](https://github.com/enisdenjo/graphql-ws/commit/16ae316b35a90d45f379336ec3ed5bedf3f2e28e))
+* **client:** Emit events for `connecting`, `connected` and `closed` ([627775b](https://github.com/enisdenjo/graphql-ws/commit/627775b8e1aca8f359607020ff2c3bcc37b50787))
+* **client:** Implement silent-reconnects ([c6f7872](https://github.com/enisdenjo/graphql-ws/commit/c6f7872126300befcc47e8e46e82342c2924f453)), closes [#7](https://github.com/enisdenjo/graphql-ws/issues/7)
+* **client:** Lazy option can be changed ([fb0ec14](https://github.com/enisdenjo/graphql-ws/commit/fb0ec1478e5219eb75e6bf2a1c2fd2a3a9cbb90d))
+
+# [1.2.0](https://github.com/enisdenjo/graphql-ws/compare/v1.1.1...v1.2.0) (2020-09-04)
+
+
+### Features
+
+* Package rename `@enisdenjo/graphql-ws` 👉 `graphql-ws`. ([494f676](https://github.com/enisdenjo/graphql-ws/commit/494f6766279325769e81f52ce7b4b442c85f9476))
+
+## [1.1.1](https://github.com/enisdenjo/graphql-ws/compare/v1.1.0...v1.1.1) (2020-08-28)
+
+
+### Bug Fixes
+
+* add the sink to the subscribed map AFTER emitting a subscribe message ([814f46c](https://github.com/enisdenjo/graphql-ws/commit/814f46c119792aaa240d0fcdb318dccdd1cc0e87))
+* notify only relevant sinks about errors or completions ([62155ba](https://github.com/enisdenjo/graphql-ws/commit/62155ba0b79516141633b86765921b2401fcc2ed))
+
+# [1.1.0](https://github.com/enisdenjo/graphql-ws/compare/v1.0.2...v1.1.0) (2020-08-28)
+
+
+### Bug Fixes
+
+* **server:** allow skipping init message wait with zero values ([a7419df](https://github.com/enisdenjo/graphql-ws/commit/a7419df077acb018418016c7a06716fb3c054ddb))
+* **server:** use subscription specific formatter for queries and mutations too ([5672a04](https://github.com/enisdenjo/graphql-ws/commit/5672a045332ea835e6ff7ce862c7c2a46729363b))
+
+
+### Features
+
+* **client:** introduce Socky 🧦 - the nifty internal socket state manager ([#8](https://github.com/enisdenjo/graphql-ws/issues/8)) ([a4bee6f](https://github.com/enisdenjo/graphql-ws/commit/a4bee6fb8c1bd56637363a76f6ab0c3b64f55931))
+
+## [1.0.2](https://github.com/enisdenjo/graphql-ws/compare/v1.0.1...v1.0.2) (2020-08-26)
+
+
+### Bug Fixes
+
+* correctly detect WebSocket server ([eab29dc](https://github.com/enisdenjo/graphql-ws/commit/eab29dcae3d031a117de37dee09770833e9573cf))
+
+## [1.0.1](https://github.com/enisdenjo/graphql-ws/compare/v1.0.0...v1.0.1) (2020-08-26)
+
+
+### Bug Fixes
+
+* reset connected/connecting state when disconnecting and disposing ([2eb3cd5](https://github.com/enisdenjo/graphql-ws/commit/2eb3cd5965cf34f6d6b21748daea520163b9c789))
+* **client:** cant read the `CloseEvent.reason` after bundling so just pass the whole event to the sink error and let the user handle it ([9ccb46b](https://github.com/enisdenjo/graphql-ws/commit/9ccb46bc80024cb2de823702d2bd308052c6c516))
+* **client:** send complete message and close only if socket is still open ([49b75ce](https://github.com/enisdenjo/graphql-ws/commit/49b75cec60fec9c8a42119b124a9c54d29d30308))
+* http and ws have no default exports ([5c01ed9](https://github.com/enisdenjo/graphql-ws/commit/5c01ed924793ce17f036d26d9d5d63cd5cecc6aa))
+* include `types` file holding important types ([f3e4edf](https://github.com/enisdenjo/graphql-ws/commit/f3e4edf96e5c6cecf025811e2beb7ecc324ea962))
+* **server:** scoped execution result formatter from `onConnect` ([f91fadb](https://github.com/enisdenjo/graphql-ws/commit/f91fadb6464a6e74f9a11555026dd5f9279df563))
+* export both the client and the server from index ([29923b1](https://github.com/enisdenjo/graphql-ws/commit/29923b1e35a462c5b5a19d64603d59f25c1c5987))
+* **server:** store the intial request in the context ([6927ee0](https://github.com/enisdenjo/graphql-ws/commit/6927ee01c0b8224f8290322a964e70382614d0e8))
+
+# [1.0.0](https://github.com/enisdenjo/graphql-ws/compare/v0.0.2...v1.0.0) (2020-08-17)
+
+
+### Features
+
+* **client:** Re-implement following the new transport protocol ([#6](https://github.com/enisdenjo/graphql-ws/issues/6)) ([5191a35](https://github.com/enisdenjo/graphql-ws/commit/5191a358098c6f9a661ae90e0420fa430db9152c))
+* **server:** Implement following the new transport protocol ([#1](https://github.com/enisdenjo/graphql-ws/issues/1)) ([a412d25](https://github.com/enisdenjo/graphql-ws/commit/a412d2570e484046a058c11f39813c7794ec9147))
+* Rewrite GraphQL over WebSocket Protocol ([#2](https://github.com/enisdenjo/graphql-ws/issues/2)) ([42045c5](https://github.com/enisdenjo/graphql-ws/commit/42045c577de9d95a81a37d850b38f4482914cebd))
 
 
 ### BREAKING CHANGES
 
-* This lib is no longer compatible with [`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws). It follows a [redesigned transport protocol](https://github.com/enisdenjo/graphql-transport-ws/blob/2b8c3f095d382d299e9e1670eb907b37591626ca/PROTOCOL.md) aiming to improve security, stability and reduce ambiguity.
+* This lib is no longer compatible with [`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws). It follows a [redesigned transport protocol](https://github.com/enisdenjo/graphql-ws/blob/2b8c3f095d382d299e9e1670eb907b37591626ca/PROTOCOL.md) aiming to improve security, stability and reduce ambiguity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Features
 
+* Package rename `graphql-transport-ws` 👉 `graphql-ws`. ([#43](https://github.com/enisdenjo/graphql-ws/pull/43))
+
 * **server:** More callbacks, clearer differences and higher extensibility ([#40](https://github.com/enisdenjo/graphql-ws/issues/40)) ([507a222](https://github.com/enisdenjo/graphql-ws/commit/507a2226719efacf6180705beb8bb9d88f80d7f3))
 
 
@@ -121,7 +123,7 @@ Dropped in favour of using the return value of `onNext` callback.
 
 ### Features
 
-* Package rename `@enisdenjo/graphql-ws` 👉 `graphql-ws`. ([494f676](https://github.com/enisdenjo/graphql-ws/commit/494f6766279325769e81f52ce7b4b442c85f9476))
+* Package rename `@enisdenjo/graphql-transport-ws` 👉 `graphql-transport-ws`. ([494f676](https://github.com/enisdenjo/graphql-ws/commit/494f6766279325769e81f52ce7b4b442c85f9476))
 
 ## [1.1.1](https://github.com/enisdenjo/graphql-ws/compare/v1.1.0...v1.1.1) (2020-08-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.9.1](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
-
-
-### Features
-
-* Package rename `graphql-transport-ws` 👉 `graphql-ws`. ([#43](https://github.com/enisdenjo/graphql-ws/pull/43))
-
 # [1.9.0](https://github.com/enisdenjo/graphql-ws/compare/v1.8.2...v1.9.0) (2020-10-24)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `graphql-transport-ws`
+# Contributing to `graphql-ws`
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   <h6>Coherent, zero-dependency, lazy, simple, <a href="PROTOCOL.md">GraphQL over WebSocket Protocol</a> compliant server and client.</h6>
 
-[![Continuous integration](https://github.com/enisdenjo/graphql-transport-ws/workflows/Continuous%20integration/badge.svg)](https://github.com/enisdenjo/graphql-transport-ws/actions?query=workflow%3A%22Continuous+integration%22) [![graphql-transport-ws](https://img.shields.io/npm/v/graphql-transport-ws.svg?label=graphql-transport-ws&logo=npm)](https://www.npmjs.com/package/graphql-transport-ws)
+[![Continuous integration](https://github.com/enisdenjo/graphql-ws/workflows/Continuous%20integration/badge.svg)](https://github.com/enisdenjo/graphql-ws/actions?query=workflow%3A%22Continuous+integration%22) [![graphql-ws](https://img.shields.io/npm/v/graphql-ws.svg?label=graphql-ws&logo=npm)](https://www.npmjs.com/package/graphql-ws)
 
   <br />
 </div>
@@ -15,7 +15,7 @@
 #### Install
 
 ```shell
-$ yarn add graphql-transport-ws
+$ yarn add graphql-ws
 ```
 
 #### Create a GraphQL schema
@@ -53,7 +53,7 @@ const roots = {
 ```ts
 import https from 'https';
 import { execute, subscribe } from 'graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 
 const server = https.createServer(function weServeSocketsOnly(_, res) {
   res.writeHead(404);
@@ -79,7 +79,7 @@ server.listen(443);
 #### Use the client
 
 ```ts
-import { createClient } from 'graphql-transport-ws';
+import { createClient } from 'graphql-ws';
 
 const client = createClient({
   url: 'wss://welcomer.com/graphql',
@@ -133,7 +133,7 @@ const client = createClient({
 <summary>Client usage with Promise</summary>
 
 ```ts
-import { createClient, SubscribePayload } from 'graphql-transport-ws';
+import { createClient, SubscribePayload } from 'graphql-ws';
 
 const client = createClient({
   url: 'wss://hey.there/graphql',
@@ -212,7 +212,7 @@ import {
   RequestParameters,
   Variables,
 } from 'relay-runtime';
-import { createClient } from 'graphql-transport-ws';
+import { createClient } from 'graphql-ws';
 
 const subscriptionsClient = createClient({
   url: 'wss://i.love/graphql',
@@ -272,7 +272,7 @@ export const network = Network.create(fetchOrSubscribe, fetchOrSubscribe);
 
 ```typescript
 import { ApolloLink, Operation, FetchResult, Observable } from '@apollo/client';
-import { createClient, Config, Client } from 'graphql-transport-ws';
+import { createClient, Config, Client } from 'graphql-ws';
 
 class WebSocketLink extends ApolloLink {
   private client: Client;
@@ -329,7 +329,7 @@ const link = new WebSocketLink({
 ```ts
 const WebSocket = require('ws'); // yarn add ws
 const Crypto = require('crypto');
-const { createClient } = require('graphql-transport-ws');
+const { createClient } = require('graphql-ws');
 
 const client = createClient({
   url: 'wss://no.browser/graphql',
@@ -356,7 +356,7 @@ const client = createClient({
 import https from 'https';
 import express from 'express';
 import { graphqlHTTP } from 'express-graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 import { execute, subscribe } from 'graphql';
 import { schema } from 'my-graphql-schema';
 
@@ -390,7 +390,7 @@ server.listen(443, () => {
 ```typescript
 import https from 'https';
 import { execute, subscribe } from 'graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 
 const server = https.createServer(function weServeSocketsOnly(_, res) {
   res.writeHead(404);
@@ -435,7 +435,7 @@ import https from 'https';
 import WebSocket from 'ws';
 import url from 'url';
 import { execute, subscribe } from 'graphql';
-import { createServer, createClient } from 'graphql-transport-ws';
+import { createServer, createClient } from 'graphql-ws';
 import { schema } from 'my-graphql-schema';
 
 const server = https.createServer(function weServeSocketsOnly(_, res) {
@@ -493,7 +493,7 @@ server.listen(443);
 
 ```typescript
 import { validate, execute, subscribe } from 'graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 import { schema, roots, getStaticContext } from 'my-graphql';
 
 createServer(
@@ -518,7 +518,7 @@ createServer(
 
 ```typescript
 import { parse, validate, execute, subscribe } from 'graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 import { schema, getDynamicContext, myValidationRules } from 'my-graphql';
 
 createServer(
@@ -559,7 +559,7 @@ createServer(
 // 🛸 server
 
 import { parse, execute, subscribe } from 'graphql';
-import { createServer } from 'graphql-transport-ws';
+import { createServer } from 'graphql-ws';
 import { schema } from 'my-graphql-schema';
 
 // a unique GraphQL execution ID used for representing
@@ -600,7 +600,7 @@ createServer(
 ```typescript
 // 📺 client
 
-import { createClient } from 'graphql-transport-ws';
+import { createClient } from 'graphql-ws';
 
 const client = createClient({
   url: 'wss://persisted.graphql/queries',

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-**[graphql-transport-ws](README.md)**
+**[graphql-ws](README.md)**
 
 > Globals
 
-# graphql-transport-ws
+# graphql-ws
 
 ## Index
 

--- a/docs/enums/_message_.messagetype.md
+++ b/docs/enums/_message_.messagetype.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / MessageType
 

--- a/docs/interfaces/_client_.client.md
+++ b/docs/interfaces/_client_.client.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["client"](../modules/_client_.md) / Client
 

--- a/docs/interfaces/_client_.clientoptions.md
+++ b/docs/interfaces/_client_.clientoptions.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["client"](../modules/_client_.md) / ClientOptions
 

--- a/docs/interfaces/_message_.completemessage.md
+++ b/docs/interfaces/_message_.completemessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / CompleteMessage
 

--- a/docs/interfaces/_message_.connectionackmessage.md
+++ b/docs/interfaces/_message_.connectionackmessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / ConnectionAckMessage
 

--- a/docs/interfaces/_message_.connectioninitmessage.md
+++ b/docs/interfaces/_message_.connectioninitmessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / ConnectionInitMessage
 

--- a/docs/interfaces/_message_.errormessage.md
+++ b/docs/interfaces/_message_.errormessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / ErrorMessage
 

--- a/docs/interfaces/_message_.nextmessage.md
+++ b/docs/interfaces/_message_.nextmessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / NextMessage
 

--- a/docs/interfaces/_message_.subscribemessage.md
+++ b/docs/interfaces/_message_.subscribemessage.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / SubscribeMessage
 

--- a/docs/interfaces/_message_.subscribepayload.md
+++ b/docs/interfaces/_message_.subscribepayload.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["message"](../modules/_message_.md) / SubscribePayload
 

--- a/docs/interfaces/_server_.context.md
+++ b/docs/interfaces/_server_.context.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["server"](../modules/_server_.md) / Context
 

--- a/docs/interfaces/_server_.server.md
+++ b/docs/interfaces/_server_.server.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["server"](../modules/_server_.md) / Server
 

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["server"](../modules/_server_.md) / ServerOptions
 

--- a/docs/interfaces/_types_.disposable.md
+++ b/docs/interfaces/_types_.disposable.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Disposable
 

--- a/docs/interfaces/_types_.sink.md
+++ b/docs/interfaces/_types_.sink.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / ["types"](../modules/_types_.md) / Sink
 

--- a/docs/modules/_client_.md
+++ b/docs/modules/_client_.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / "client"
 

--- a/docs/modules/_message_.md
+++ b/docs/modules/_message_.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / "message"
 

--- a/docs/modules/_protocol_.md
+++ b/docs/modules/_protocol_.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / "protocol"
 

--- a/docs/modules/_server_.md
+++ b/docs/modules/_server_.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / "server"
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -1,4 +1,4 @@
-**[graphql-transport-ws](../README.md)**
+**[graphql-ws](../README.md)**
 
 > [Globals](../README.md) / "types"
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-transport-ws",
+  "name": "graphql-ws",
   "version": "1.9.0",
   "description": "Coherent, zero-dependency, lazy, simple, GraphQL over WebSocket Protocol compliant server and client",
   "keywords": [
@@ -16,10 +16,10 @@
     "apollo"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/enisdenjo/graphql-transport-ws#readme",
+  "homepage": "https://github.com/enisdenjo/graphql-ws#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/enisdenjo/graphql-transport-ws.git"
+    "url": "git+https://github.com/enisdenjo/graphql-ws.git"
   },
   "main": "lib/index.js",
   "browser": "lib/client.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,9 +1218,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@eslint/eslintrc@npm:0.1.3"
+"@eslint/eslintrc@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@eslint/eslintrc@npm:0.2.0"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.1.1
@@ -1232,7 +1232,7 @@ __metadata:
     lodash: ^4.17.19
     minimatch: ^3.0.4
     strip-json-comments: ^3.1.1
-  checksum: e9c5eaa5e706bcedbba6e7e1a2bc85faa7e3a9edbe71375e07240d1b6540fbb88d907bd5e5841b42c2a7a9683dcf031ea052c447c3c9d81ba4d0b74f0dd67e5f
+  checksum: bdc8346add0fe57337c09134f19e693fa8a3c03357bf54c05de2270388774b0469b6d6dbd9f368cbd5de53919c4c9e8b644177acc417ea1ff4f99cbf32feefa6
   languageName: node
   linkType: hard
 
@@ -2801,9 +2801,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001135":
-  version: 1.0.30001150
-  resolution: "caniuse-lite@npm:1.0.30001150"
-  checksum: ff8944b2ca6db465e9e878be38f66efad7f4a8cf06aea7c3d463b428649266f75b84dddd130fd3fd46841e160cfac3cfedbe40f3434f428ceaaa709ef6b8b2b1
+  version: 1.0.30001151
+  resolution: "caniuse-lite@npm:1.0.30001151"
+  checksum: 3acb52ac17034d7abe4468e66293c9e5597cb5f123bd8f86ea3b87e758112ac4259fdbc35f8f4cbf5477e385dd975f11031bfbf26f4cec64d64a0c567a430b58
   languageName: node
   linkType: hard
 
@@ -3984,11 +3984,11 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^7.11.0":
-  version: 7.11.0
-  resolution: "eslint@npm:7.11.0"
+  version: 7.12.0
+  resolution: "eslint@npm:7.12.0"
   dependencies:
     "@babel/code-frame": ^7.0.0
-    "@eslint/eslintrc": ^0.1.3
+    "@eslint/eslintrc": ^0.2.0
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
@@ -4026,7 +4026,7 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: 45ef6dc7b31684ca0f383ed9c6224e763197e1d49745542f4440e37286c947973388a6a7ebbf103eeee91ddb4af2652c5d22718f4130bfbbf4bd16a04103f82a
+  checksum: 22f86c0ebaf75993d197d230a8c35f11ba4ffc7cd0b280aeecb28a04c26446b9e6906eedee264a445311a3b9b31f9bca787ee58546acc087cb2c1056ca89f624
   languageName: node
   linkType: hard
 
@@ -4782,9 +4782,9 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"graphql-transport-ws@workspace:.":
+"graphql-ws@workspace:.":
   version: 0.0.0-use.local
-  resolution: "graphql-transport-ws@workspace:."
+  resolution: "graphql-ws@workspace:."
   dependencies:
     "@babel/core": ^7.12.3
     "@babel/plugin-proposal-class-properties": ^7.12.1


### PR DESCRIPTION
Aiming towards simplicity, this PR proposes renaming the library from `graphql-transport-ws` to `graphql-ws`. The old package will be deprecated and all versions as of v1 will be ported to the new name.

### TODO

- [ ] Deprecate [`graphql-transport-ws`](https://www.npmjs.com/package/graphql-transport-ws) at npm
- [x] Deprecate old versions of [`graphql-ws`](https://www.npmjs.com/package/graphql-ws) at npm
- [ ] ~Release all v1+ versions to `graphql-ws`~ Release new version `v1.9.1`.
