### PR TITLE
feat: `Subscribe` message query must be a string

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -62,14 +62,12 @@ Requests an operation specified in the message `payload`. This message provides 
 If there is already an active subscriber for a streaming operation matching the provided ID, the server will close the socket immediately with the event `4409: Subscriber for <unique-operation-id> already exists`. The server may not assert this rule for operations returning a single result as they do not require reservations for additional future events.
 
 ```typescript
-import { DocumentNode } from 'graphql';
-
 interface SubscribeMessage {
   id: '<unique-operation-id>';
   type: 'subscribe';
   payload: {
     operationName?: string | null;
-    query: string | DocumentNode;
+    query: string;
     variables?: Record<string, unknown> | null;
   };
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { GraphQLError, ExecutionResult, DocumentNode } from 'graphql';
+import { GraphQLError, ExecutionResult } from 'graphql';
 import {
   isObject,
   areGraphQLErrors,
@@ -41,7 +41,7 @@ export interface SubscribeMessage {
 
 export interface SubscribePayload {
   readonly operationName?: string | null;
-  readonly query: string | DocumentNode;
+  readonly query: string;
   readonly variables?: Record<string, unknown> | null;
 }
 
@@ -104,8 +104,7 @@ export function isMessage(val: unknown): val is Message {
             val.payload.operationName === undefined ||
             val.payload.operationName === null ||
             typeof val.payload.operationName === 'string') &&
-          (hasOwnStringProperty(val.payload, 'query') || // string query or persisted query id
-            hasOwnObjectProperty(val.payload, 'query')) && // document node query
+          hasOwnStringProperty(val.payload, 'query') &&
           (!hasOwnProperty(val.payload, 'variables') ||
             val.payload.variables === undefined ||
             val.payload.variables === null ||

--- a/src/server.ts
+++ b/src/server.ts
@@ -567,11 +567,10 @@ export function createServer(
               }
 
               const { operationName, query, variables } = message.payload;
-              const document = typeof query === 'string' ? parse(query) : query;
               execArgs = {
                 schema,
                 operationName,
-                document,
+                document: parse(query),
                 variableValues: variables,
               };
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1164,51 +1164,6 @@ describe('Subscribe', () => {
     });
   });
 
-  it('should execute the query of `DocumentNode` type, "next" the result and then "complete"', async () => {
-    const { url } = await startTServer({
-      schema,
-    });
-
-    const client = await createTClient(url);
-    client.ws.send(
-      stringifyMessage<MessageType.ConnectionInit>({
-        type: MessageType.ConnectionInit,
-      }),
-    );
-
-    await client.waitForMessage(({ data }) => {
-      expect(parseMessage(data).type).toBe(MessageType.ConnectionAck);
-      client.ws.send(
-        stringifyMessage<MessageType.Subscribe>({
-          id: '1',
-          type: MessageType.Subscribe,
-          payload: {
-            operationName: 'TestString',
-            query: parse(`query TestString {
-              getValue
-            }`),
-            variables: {},
-          },
-        }),
-      );
-    });
-
-    await client.waitForMessage(({ data }) => {
-      expect(parseMessage(data)).toEqual({
-        id: '1',
-        type: MessageType.Next,
-        payload: { data: { getValue: 'value' } },
-      });
-    });
-
-    await client.waitForMessage(({ data }) => {
-      expect(parseMessage(data)).toEqual({
-        id: '1',
-        type: MessageType.Complete,
-      });
-    });
-  });
-
   it('should execute the query and "error" out because of validation errors', async () => {
     const { url } = await startTServer({
       schema,


### PR DESCRIPTION
Closes #44

Because of parity with HTTP conventions and reasons such as:
- Size _(the serialised `Document` object can be much bigger than a simple query)_
- Security _(no objects allowed through the `query` field, must provide parsable query)_
- Implementation independent _(#44)_

it might make sense to strictly require the `query` field to be of a string type.

However, there are reasons where we want to support the `Document` object too:
- ~~Performance _(you might have a ready `Document` to be sent from the client to avoid query parsing altogether)_~~ negligible
- You might want to use [`graphql-tag`](https://github.com/apollographql/graphql-tag) and get tooling support _(like from Prettier or syntax highlighting)_
- You use the [Apollo Client GraphQLRequest type](https://github.com/apollographql/apollo-client/blob/b878385257223d1e45479033ff5dc5e3a4f7a4ab/src/link/core/types.ts#L6-L12). Like in [the WS link](https://github.com/apollographql/apollo-client/blob/e145a860a10c12fdc4d863379f32e4080597323b/src/link/ws/index.ts#L51)
- You use the [Urql GraphQLRequestType](https://github.com/FormidableLabs/urql/blob/db7412ea56358dc057b225e6f13713ca16e27173/packages/core/src/types.ts#L25-L31)
- The [RequestDocument from `graphql-request` supports both types too](https://github.com/prisma-labs/graphql-request/blob/c75a29a9a2a177b0cddb41718b333fb14c9d9917/src/types.ts#L56)

Following the comment https://github.com/graphql/graphql-over-http/pull/140#discussion_r516708794, the Protocol must require the `query` field in the subscribe message to be a `string`.

**Beware**, this library is intended to be another tool in your workspace; in order to keep it secure, small, lean and 1:1 representation of the Protocol - the library will drop the `DocumentNode` support from the message too. Please use the `graphql.print(ast)` to stringify to query yourself, before calling the subscribe method. (Check Apollo Client recipe)