### PR TITLE
feat(server): For dynamic usage, `context` option can be a function too

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,16 +490,18 @@ server.listen(443);
 </details>
 
 <details>
-<summary>Server usage with custom static GraphQL arguments</summary>
+<summary>Server usage with custom GraphQL context value</summary>
 
 ```typescript
 import { validate, execute, subscribe } from 'graphql';
 import { createServer } from 'graphql-ws';
-import { schema, roots, getStaticContext } from 'my-graphql';
+import { schema, roots, getDynamicContext } from 'my-graphql';
 
 createServer(
   {
-    context: getStaticContext(),
+    context: (ctx, msg, args) => {
+      return getDynamicContext(ctx, msg, args);
+    }, // or static context by supplying the value direcly
     schema,
     roots,
     execute,

--- a/README.md
+++ b/README.md
@@ -515,12 +515,12 @@ createServer(
 </details>
 
 <details>
-<summary>Server usage with custom dynamic GraphQL arguments and validation</summary>
+<summary>Server usage with custom execution arguments and validation</summary>
 
 ```typescript
 import { parse, validate, execute, subscribe } from 'graphql';
 import { createServer } from 'graphql-ws';
-import { schema, getDynamicContext, myValidationRules } from 'my-graphql';
+import { schema, myValidationRules } from 'my-graphql';
 
 createServer(
   {
@@ -529,7 +529,6 @@ createServer(
     onSubscribe: (ctx, msg) => {
       const args = {
         schema,
-        contextValue: getDynamicContext(ctx, msg),
         operationName: msg.payload.operationName,
         document: parse(msg.payload.query),
         variableValues: msg.payload.variables,

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ server.listen(443);
 </details>
 
 <details>
-<summary>Server usage with custom GraphQL context value</summary>
+<summary>Server usage with custom context value</summary>
 
 ```typescript
 import { validate, execute, subscribe } from 'graphql';

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -48,15 +48,16 @@ ___
 
 ### context
 
-• `Optional` **context**: unknown
+• `Optional` **context**: [GraphQLExecutionContextValue](../modules/_server_.md#graphqlexecutioncontextvalue) \| (ctx: [Context](_server_.context.md), message: [SubscribeMessage](_message_.subscribemessage.md), args: ExecutionArgs) => [GraphQLExecutionContextValue](../modules/_server_.md#graphqlexecutioncontextvalue)
 
 A value which is provided to every resolver and holds
 important contextual information like the currently
 logged in user, or access to a database.
 
-If you return from the `onSubscribe` callback, this
-context value will NOT be injected. You should add it
-in the returned `ExecutionArgs` from the callback.
+If you return from `onSubscribe`, and the returned value is
+missing the `contextValue` field, this context will be used
+instead. The returned value will be passed through as the
+execution arguments, if you use the function signature.
 
 ___
 
@@ -199,7 +200,10 @@ If you return `ExecutionArgs` from the callback,
 it will be used instead of trying to build one
 internally. In this case, you are responsible
 for providing a ready set of arguments which will
-be directly plugged in the operation execution.
+be directly plugged in the operation execution. Beware,
+the `context` server option is an exception. Only if you
+dont provide a context alongside the returned value
+here, the `context` server option will be used instead.
 
 To report GraphQL errors simply return an array
 of them from the callback, they will be reported

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -56,8 +56,12 @@ logged in user, or access to a database.
 
 If you return from `onSubscribe`, and the returned value is
 missing the `contextValue` field, this context will be used
-instead. The returned value will be passed through as the
-execution arguments, if you use the function signature.
+instead.
+
+If you use the function signature, the final execution arguments
+will be passed in (also the returned value from `onSubscribe`).
+Since the context is injected on every subscribe, the `SubscribeMessage`
+with the regular `Context` will be passed in through the arguments too.
 
 ___
 

--- a/docs/modules/_server_.md
+++ b/docs/modules/_server_.md
@@ -14,6 +14,7 @@
 
 ### Type aliases
 
+* [GraphQLExecutionContextValue](_server_.md#graphqlexecutioncontextvalue)
 * [OperationResult](_server_.md#operationresult)
 
 ### Functions
@@ -21,6 +22,19 @@
 * [createServer](_server_.md#createserver)
 
 ## Type aliases
+
+### GraphQLExecutionContextValue
+
+Ƭ  **GraphQLExecutionContextValue**: object \| symbol \| number \| string \| boolean \| null \| undefined
+
+A concrete GraphQL execution context value type.
+
+Mainly used because TypeScript collapes unions
+with `any` or `unknown` to `any` or `unknown`. So,
+we use a custom type to allow definitions such as
+the `context` server option.
+
+___
 
 ### OperationResult
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -594,6 +594,11 @@ export function createServer(
               ]);
             }
 
+            // if onsubscribe didnt return anything, inject roots
+            if (!maybeExecArgsOrErrors) {
+              execArgs.rootValue = roots?.[operationAST.operation];
+            }
+
             // inject the context, if provided, before the operation.
             // but, only if the `onSubscribe` didnt provide one already
             if (context !== undefined && !execArgs.contextValue) {
@@ -601,11 +606,6 @@ export function createServer(
                 typeof context === 'function'
                   ? context(ctx, message, execArgs)
                   : context;
-            }
-
-            // if onsubscribe didnt return anything, inject roots
-            if (!maybeExecArgsOrErrors) {
-              execArgs.rootValue = roots?.[operationAST.operation];
             }
 
             // the execution arguments have been prepared

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,7 +174,10 @@ export interface ServerOptions {
    * it will be used instead of trying to build one
    * internally. In this case, you are responsible
    * for providing a ready set of arguments which will
-   * be directly plugged in the operation execution.
+   * be directly plugged in the operation execution. Beware,
+   * the `context` server option is an exception. Only if you
+   * dont provide a context alongside the returned value
+   * here, the `context` server option will be used instead.
    *
    * To report GraphQL errors simply return an array
    * of them from the callback, they will be reported

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,8 +78,12 @@ export interface ServerOptions {
    *
    * If you return from `onSubscribe`, and the returned value is
    * missing the `contextValue` field, this context will be used
-   * instead. The returned value will be passed through as the
-   * execution arguments, if you use the function signature.
+   * instead.
+   *
+   * If you use the function signature, the final execution arguments
+   * will be passed in (also the returned value from `onSubscribe`).
+   * Since the context is injected on every subscribe, the `SubscribeMessage`
+   * with the regular `Context` will be passed in through the arguments too.
    */
   context?:
     | GraphQLExecutionContextValue

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,8 +58,7 @@ export type GraphQLExecutionContextValue =
   | number
   | string
   | boolean
-  | null
-  | undefined;
+  | null;
 
 export interface ServerOptions {
   /**
@@ -597,7 +596,7 @@ export function createServer(
 
             // inject the context, if provided, before the operation.
             // but, only if the `onSubscribe` didnt provide one already
-            if (context && !execArgs.contextValue) {
+            if (context !== undefined && !execArgs.contextValue) {
               execArgs.contextValue =
                 typeof context === 'function'
                   ? context(ctx, message, execArgs)

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,24 @@ export type OperationResult =
   | AsyncIterableIterator<ExecutionResult>
   | ExecutionResult;
 
+/**
+ * A concrete GraphQL execution context value type.
+ *
+ * Mainly used because TypeScript collapes unions
+ * with `any` or `unknown` to `any` or `unknown`. So,
+ * we use a custom type to allow definitions such as
+ * the `context` server option.
+ */
+export type GraphQLExecutionContextValue =
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | object // you can literally pass "any" JS object as the context value
+  | symbol
+  | number
+  | string
+  | boolean
+  | null
+  | undefined;
+
 export interface ServerOptions {
   /**
    * The GraphQL schema on which the operations
@@ -64,12 +82,12 @@ export interface ServerOptions {
    * execution arguments, if you use the function signature.
    */
   context?:
-    | unknown
+    | GraphQLExecutionContextValue
     | ((
         ctx: Context,
         message: SubscribeMessage,
         args: ExecutionArgs,
-      ) => unknown);
+      ) => GraphQLExecutionContextValue);
   /**
    * The GraphQL root fields or resolvers to go
    * alongside the schema. Learn more about them


### PR DESCRIPTION
Inspired by https://github.com/enisdenjo/graphql-ws/issues/36#issuecomment-721095047

Helpful for when you want a dynamic context, but you want to avoid using the `onSubscribe` because you have to set the complete execution arguments up.