### PR TITLE
fix(server): Consistently set `rootValue` and `contextValue`, if not overridden

### DIFF
--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -204,10 +204,11 @@ If you return `ExecutionArgs` from the callback,
 it will be used instead of trying to build one
 internally. In this case, you are responsible
 for providing a ready set of arguments which will
-be directly plugged in the operation execution. Beware,
-the `context` server option is an exception. Only if you
-dont provide a context alongside the returned value
-here, the `context` server option will be used instead.
+be directly plugged in the operation execution.
+
+Omitting the fields `contextValue` or `rootValue`
+from the returned value will have the provided server
+options fill in the gaps.
 
 To report GraphQL errors simply return an array
 of them from the callback, they will be reported
@@ -233,9 +234,9 @@ The GraphQL root fields or resolvers to go
 alongside the schema. Learn more about them
 here: https://graphql.org/learn/execution/#root-fields-resolvers.
 
-If you return from the `onSubscribe` callback, the
-root field value will NOT be injected. You should add it
-in the returned `ExecutionArgs` from the callback.
+If you return from `onSubscribe`, and the returned value is
+missing the `rootValue` field, the relevant operation root
+will be used instead.
 
 ___
 

--- a/docs/modules/_server_.md
+++ b/docs/modules/_server_.md
@@ -25,7 +25,7 @@
 
 ### GraphQLExecutionContextValue
 
-Ƭ  **GraphQLExecutionContextValue**: object \| symbol \| number \| string \| boolean \| null
+Ƭ  **GraphQLExecutionContextValue**: object \| symbol \| number \| string \| boolean \| undefined \| null
 
 A concrete GraphQL execution context value type.
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -593,14 +593,13 @@ export function createServer(
               ]);
             }
 
-            // if onsubscribe didnt return anything, inject roots
-            if (!maybeExecArgsOrErrors) {
+            // if `onSubscribe` didnt specify a rootValue, inject one
+            if (!('rootValue' in execArgs)) {
               execArgs.rootValue = roots?.[operationAST.operation];
             }
 
-            // inject the context, if provided, before the operation.
-            // but, only if the `onSubscribe` didnt provide one already
-            if (context !== undefined && !execArgs.contextValue) {
+            // if `onSubscribe` didn't specify a context, inject one
+            if (!('contextValue' in execArgs)) {
               execArgs.contextValue =
                 typeof context === 'function'
                   ? context(ctx, message, execArgs)

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,7 @@ export type GraphQLExecutionContextValue =
   | number
   | string
   | boolean
+  | undefined
   | null;
 
 export interface ServerOptions {
@@ -96,9 +97,9 @@ export interface ServerOptions {
    * alongside the schema. Learn more about them
    * here: https://graphql.org/learn/execution/#root-fields-resolvers.
    *
-   * If you return from the `onSubscribe` callback, the
-   * root field value will NOT be injected. You should add it
-   * in the returned `ExecutionArgs` from the callback.
+   * If you return from `onSubscribe`, and the returned value is
+   * missing the `rootValue` field, the relevant operation root
+   * will be used instead.
    */
   roots?: {
     [operation in OperationTypeNode]?: Record<
@@ -177,10 +178,11 @@ export interface ServerOptions {
    * it will be used instead of trying to build one
    * internally. In this case, you are responsible
    * for providing a ready set of arguments which will
-   * be directly plugged in the operation execution. Beware,
-   * the `context` server option is an exception. Only if you
-   * dont provide a context alongside the returned value
-   * here, the `context` server option will be used instead.
+   * be directly plugged in the operation execution.
+   *
+   * Omitting the fields `contextValue` or `rootValue`
+   * from the returned value will have the provided server
+   * options fill in the gaps.
    *
    * To report GraphQL errors simply return an array
    * of them from the callback, they will be reported

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -790,7 +790,7 @@ describe('Subscribe', () => {
       schema,
       operationName: 'Nope',
       document: parse(`query Nope { getValue }`),
-      rootValue: undefined,
+      rootValue: null,
     };
     const { url } = await startTServer({
       schema: undefined,
@@ -799,7 +799,7 @@ describe('Subscribe', () => {
       },
       execute: (args) => {
         expect(args.schema).toBe(nopeArgs.schema); // schema from nopeArgs
-        expect(args.rootValue).toBeUndefined(); // nopeArgs didnt provide any root value
+        expect(args.rootValue).toBeNull(); // nopeArgs provided rootValue: null, so don't overwrite
         expect(args.operationName).toBe('Nope');
         expect(args.variableValues).toBeUndefined(); // nopeArgs didnt provide variables
         return execute(args);

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -790,6 +790,7 @@ describe('Subscribe', () => {
       schema,
       operationName: 'Nope',
       document: parse(`query Nope { getValue }`),
+      rootValue: undefined,
     };
     const { url } = await startTServer({
       schema: undefined,


### PR DESCRIPTION
Previously we had:

- rootValue is only overwritten if onSubscribe didn't return anything
- context is overwritten if onSubscribe didn't return anything OR if onSubscribe's return value doesn't state context.

This PR makes this behaviour consistent by replacing the `rootValue` condition with:

- rootValue is overwritten if onSubscribe didn't return anything OR if onSubscribe's return value doesn't state rootValue

It also adjusts the check such that a user returning `contextValue: null` or `rootValue: null` (or anything else falsy) from `onSubscribe` will not have those values overwritten.