### PR TITLE
refactor: support array of protocols

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -353,10 +353,9 @@ export function createServer(
 
   function handleConnection(socket: WebSocket, request: http.IncomingMessage) {
     if (
-      socket.protocol === undefined ||
-      socket.protocol !== GRAPHQL_TRANSPORT_WS_PROTOCOL ||
-      (Array.isArray(socket.protocol) &&
-        socket.protocol.indexOf(GRAPHQL_TRANSPORT_WS_PROTOCOL) === -1)
+      Array.isArray(socket.protocol)
+        ? socket.protocol.indexOf(GRAPHQL_TRANSPORT_WS_PROTOCOL) === -1
+        : socket.protocol !== GRAPHQL_TRANSPORT_WS_PROTOCOL
     ) {
       return socket.close(1002, 'Protocol Error');
     }


### PR DESCRIPTION
The previous logic here had `socket.protocol === undefined || socket.protocol !== GRAPHQL_TRANSPORT_WS_PROTOCOL` which was redundant (`undefined !== GRAPHQL_TRANSPORT_WS_PROTOCOL`), and further had `|| (Array.isArray(...) && ...)` which would never be evaluated since any array would be shortcut by the `socket.protocol !== GRAPHQL_TRANSPORT_WS_PROTOCOL` check. I believe this PR changes the logic to what was intended.