### PR TITLE
perf: reduces runtime prototype traversal for hasOwnProperty

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,9 @@
  */
 import { GraphQLError } from 'graphql';
 
+// Extremely small optimisation, reduces runtime prototype traversal
+const baseHasOwnProperty = Object.prototype.hasOwnProperty;
+
 export function isObject(val: unknown): val is Record<PropertyKey, unknown> {
   return typeof val === 'object' && val !== null;
 }
@@ -29,31 +32,26 @@ export function hasOwnProperty<
   O extends Record<PropertyKey, unknown>,
   P extends PropertyKey
 >(obj: O, prop: P): obj is O & Record<P, unknown> {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
+  return baseHasOwnProperty.call(obj, prop);
 }
 
 export function hasOwnObjectProperty<
   O extends Record<PropertyKey, unknown>,
   P extends PropertyKey
 >(obj: O, prop: P): obj is O & Record<P, Record<PropertyKey, unknown>> {
-  return Object.prototype.hasOwnProperty.call(obj, prop) && isObject(obj[prop]);
+  return baseHasOwnProperty.call(obj, prop) && isObject(obj[prop]);
 }
 
 export function hasOwnArrayProperty<
   O extends Record<PropertyKey, unknown>,
   P extends PropertyKey
 >(obj: O, prop: P): obj is O & Record<P, unknown[]> {
-  return (
-    Object.prototype.hasOwnProperty.call(obj, prop) && Array.isArray(obj[prop])
-  );
+  return baseHasOwnProperty.call(obj, prop) && Array.isArray(obj[prop]);
 }
 
 export function hasOwnStringProperty<
   O extends Record<PropertyKey, unknown>,
   P extends PropertyKey
 >(obj: O, prop: P): obj is O & Record<P, string> {
-  return (
-    Object.prototype.hasOwnProperty.call(obj, prop) &&
-    typeof obj[prop] === 'string'
-  );
+  return baseHasOwnProperty.call(obj, prop) && typeof obj[prop] === 'string';
 }


### PR DESCRIPTION
We call the various `hasOwnProperty` helpers a lot; this PR reduces the number of prototype traversals used at runtime. It has no measurable performance impact on V8 unless `Object.prototype` has been tampered with, and even then the difference is negligible. But it does reduce lines of code :man_shrugging:

Feel free to close this, it brings little value and is mostly just personal preference.


<details>
<summary>Benchmark code</summary>

Run with `node --expose-gc perf.js`; benchmark based on: https://benediktmeurer.de/2017/09/07/restoring-for-in-peak-performance/

Results:

```
forInHasOwnPropertySafeDeref: 22874 ms.
forInHasOwnPropertySafe: 23460 ms.
forInSumSafeDeref: 26776 ms.
forInSumSafe: 26874 ms.
```

Interpretation: dereferenced version is 2.5% or 0.4% faster.

```js
if (typeof console === 'undefined') console = { log: print };

// Taint the object prototype
Object.prototype.tainted = true;

const baseHasOwnProperty = Object.prototype.hasOwnProperty;

function forInHasOwnPropertySafe(o) {
  var result = 0;
  for (var i in o) {
    if (Object.prototype.hasOwnProperty.call(o, i)) {
      result += 1;
    }
  }
  return result;
}

function forInHasOwnPropertySafeDeref(o) {
  var result = 0;
  for (var i in o) {
    if (baseHasOwnProperty.call(o, i)) {
      result += 1;
    }
  }
  return result;
}

function forInSumSafe(o) {
  var result = 0;
  for (var i in o) {
    if (Object.prototype.hasOwnProperty.call(o, i)) {
      result += o[i];
    }
  }
  return result;
}

function forInSumSafeDeref(o) {
  var result = 0;
  for (var i in o) {
    if (baseHasOwnProperty.call(o, i)) {
      result += o[i];
    }
  }
  return result;
}

var TESTS = [
  forInHasOwnPropertySafeDeref,
  forInHasOwnPropertySafe,
  forInSumSafeDeref,
  forInSumSafe,
];
var o = Object.assign(Object.create(null), { w: 0, x: 1, y: 2, z: 3 });
var n = 1e8;

function runTest(fn) {
  var result;
  for (var i = 0; i < n; ++i) result = fn(o);
  return result;
}

// Warmup
for (var current = 0; current < TESTS.length; ++current) {
  const currentTest = TESTS[current];
  runTest(currentTest);
  console.log(`Warmed up ${currentTest.name}`);
}

function runTests(current = 0) {
  if (current >= TESTS.length) {
    return;
  }
  const currentTest = TESTS[current];
  global.gc();
  // Wait until next tick so GC can complete
  setTimeout(() => {
    var startTime = Date.now();
    runTest(currentTest);
    console.log(currentTest.name + ':', Date.now() - startTime, 'ms.');
    runTests(current + 1);
  }, 0);
}

console.log('Starting main test');

runTests();

```


</details>