### PR TITLE
fix(server): Close socket if `onSubscribe` returns invalid array

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -553,11 +553,9 @@ export function createServer(
               if (areGraphQLErrors(maybeExecArgsOrErrors)) {
                 return await emit.error(maybeExecArgsOrErrors);
               } else if (Array.isArray(maybeExecArgsOrErrors)) {
-                return await emit.error([
-                  new GraphQLError(
-                    'Invalid return value from onSubscribe hook, expected an array of GraphQLError objects',
-                  ),
-                ]);
+                throw new Error(
+                  'Invalid return value from onSubscribe hook, expected an array of GraphQLError objects',
+                );
               }
               // not errors, is exec args
               execArgs = maybeExecArgsOrErrors;

--- a/src/server.ts
+++ b/src/server.ts
@@ -552,6 +552,12 @@ export function createServer(
             if (maybeExecArgsOrErrors) {
               if (areGraphQLErrors(maybeExecArgsOrErrors)) {
                 return await emit.error(maybeExecArgsOrErrors);
+              } else if (Array.isArray(maybeExecArgsOrErrors)) {
+                return await emit.error([
+                  new GraphQLError(
+                    'Invalid return value from onSubscribe hook, expected an array of GraphQLError objects',
+                  ),
+                ]);
               }
               // not errors, is exec args
               execArgs = maybeExecArgsOrErrors;

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -895,6 +895,44 @@ describe('Subscribe', () => {
     }, 30);
   });
 
+  it('should close the socket on empty arrays returned from `onSubscribe`', async () => {
+    const { url } = await startTServer({
+      onSubscribe: () => {
+        return [];
+      },
+    });
+
+    const client = await createTClient(url);
+
+    client.ws.send(
+      stringifyMessage<MessageType.ConnectionInit>({
+        type: MessageType.ConnectionInit,
+      }),
+    );
+
+    await client.waitForMessage(({ data }) => {
+      expect(parseMessage(data).type).toBe(MessageType.ConnectionAck);
+    });
+
+    client.ws.send(
+      stringifyMessage<MessageType.Subscribe>({
+        id: '1',
+        type: MessageType.Subscribe,
+        payload: {
+          query: 'subscription { ping }',
+        },
+      }),
+    );
+
+    await client.waitForClose((event) => {
+      expect(event.code).toBe(4400);
+      expect(event.reason).toBe(
+        'Invalid return value from onSubscribe hook, expected an array of GraphQLError objects',
+      );
+      expect(event.wasClean).toBeTruthy();
+    });
+  });
+
   it('should use the execution result returned from `onNext`', async () => {
     const { url } = await startTServer({
       onNext: (_ctx, _message) => {


### PR DESCRIPTION
At the moment an empty array, or an array of things that don't match the error requirements, will be interpreted as `execArgs` which'll then cause all property references to be null and to have confusing errors thrown. This change handles the case where an array is returned but it doesn't match the requirements for an error array.

I'm not sure if emitting the error like this is the best route?