### PR TITLE
fix: handle error from operationResult stream

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -640,11 +640,16 @@ export function createServer(
               }
               ctx.subscriptions[message.id] = operationResult;
 
-              for await (const result of operationResult) {
-                await emit.next(result, execArgs);
+              try {
+                for await (const result of operationResult) {
+                  await emit.next(result, execArgs);
+                }
+                await emit.complete();
+              } catch (err) {
+                await emit.error(err);
+              } finally {
+                delete ctx.subscriptions[message.id];
               }
-              await emit.complete();
-              delete ctx.subscriptions[message.id];
             } else {
               /** single emitted result */
 


### PR DESCRIPTION
In general `operationResult` should only stream successes or the end of the stream; however I imagine that there could be a circumstance in which it'd reject, throwing an error from the `for await`; this handles that case. I'm not sure if this is the correct direction; it just occurred to me that there wasn't any local error handling here and maybe there should be?