### PR TITLE
fix: don't surface error details in production

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -664,7 +664,7 @@ export function createServer(
         }
       } catch (err) {
         // TODO-db-201031 we perceive this as a client bad request error, but is it always?
-        ctx.socket.close(4400, err.message);
+        ctx.socket.close(4400, isProd ? 'Bad Request Error' : err.message);
       }
     };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -664,7 +664,7 @@ export function createServer(
         }
       } catch (err) {
         // TODO-db-201031 we perceive this as a client bad request error, but is it always?
-        ctx.socket.close(4400, isProd ? 'Bad Request Error' : err.message);
+        ctx.socket.close(4400, isProd ? 'Bad Request' : err.message);
       }
     };
   }


### PR DESCRIPTION
This is for consistency with https://github.com/enisdenjo/graphql-ws/blob/5cc9770c60069159feea9be993bccd71c9ce8485/src/server.ts#L427-L430 - I'm not sure if that's desired or if these errors are safe to emit. If they are safe to emit, then a comment stating such would be good :+1: 