### PR TITLE
fix(server): Distribute server error to all clients even if one error listener throws

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -445,7 +445,11 @@ export function createServer(
   webSocketServer.on('error', (err) => {
     for (const client of webSocketServer.clients) {
       // report server errors by erroring out all clients with the same error
-      client.emit('error', err);
+      try {
+        client.emit('error', err);
+      } catch (e) {
+        /* noop */
+      }
     }
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -443,13 +443,20 @@ export function createServer(
   }
   webSocketServer.on('connection', handleConnection);
   webSocketServer.on('error', (err) => {
+    // catch the first thrown error and re-throw it once all clients have been notified
+    let firstErr: Error | null = null;
+
+    // report server errors by erroring out all clients with the same error
     for (const client of webSocketServer.clients) {
-      // report server errors by erroring out all clients with the same error
       try {
         client.emit('error', err);
-      } catch (e) {
-        /* noop */
+      } catch (err) {
+        firstErr = firstErr ?? err;
       }
+    }
+
+    if (firstErr) {
+      throw firstErr;
     }
   });
 


### PR DESCRIPTION
At the moment if the `'error'` handler for one of the clients were to throw then the `'error'` event won't be passed on to any further clients. This is probably not desired? I've wrapped it with a `try/catch` to allow the additional clients to be warned. However, I'm not happy with discarding the error here - we should raise it somehow. We could do something like `let firstError = null`; store the error to firstError in the catch, and then throw if firstError exists... Or we could log... Or... What do you want to do here?