### PR TITLE
refactor: use Object.values instead of .entries

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -430,11 +430,9 @@ export function createServer(
         );
       }
 
-      Object.entries(ctxRef.current.subscriptions).forEach(
-        ([, subscription]) => {
-          subscription.return?.();
-        },
-      );
+      Object.values(ctxRef.current.subscriptions).forEach((subscription) => {
+        subscription.return?.();
+      });
     }
 
     socket.onerror = errorOrCloseHandler;


### PR DESCRIPTION
I believe `Object.values` is supported everywhere than `Object.entries` is supported.