### PR TITLE
fix: Stop sending messages after receiving complete

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -497,7 +497,7 @@ export function createClient(options: ClientOptions): Client {
             // either the canceller will be called and the promise resolved
             // or the socket closed and the promise rejected
             await throwOnCloseOrWaitForCancel(() => {
-              if (!completed && socket.readyState === WebSocketImpl.OPEN) {
+              if (!completed) {
                 // send complete message to server on cancel
                 socket.send(
                   stringifyMessage<MessageType.Complete>({

--- a/src/client.ts
+++ b/src/client.ts
@@ -497,8 +497,8 @@ export function createClient(options: ClientOptions): Client {
             // either the canceller will be called and the promise resolved
             // or the socket closed and the promise rejected
             await throwOnCloseOrWaitForCancel(() => {
+              // if not completed already, send complete message to server on cancel
               if (!completed) {
-                // send complete message to server on cancel
                 socket.send(
                   stringifyMessage<MessageType.Complete>({
                     id: id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -684,7 +684,7 @@ export function createServer(
               }
 
               // lack of subscription at this point indicates that the client
-              // completed the stream, he doesnt need to be remembered
+              // completed the stream, he doesnt need to be reminded
               await emit.complete(Boolean(ctx.subscriptions[message.id]));
               delete ctx.subscriptions[message.id];
             } else {

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -204,7 +204,7 @@ it('should close with error message during connecting issues', async () => {
 
 describe('query operation', () => {
   it('should execute the query, "next" the result and then complete', async () => {
-    const { url, ...server } = await startTServer();
+    const { url } = await startTServer();
 
     const client = createClient({ url });
 
@@ -217,8 +217,6 @@ describe('query operation', () => {
     });
 
     await sub.waitForComplete();
-
-    await server.waitForClientClose();
   });
 
   it('should accept nullish value for `operationName` and `variables`', async () => {

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -380,6 +380,30 @@ describe('subscription operation', () => {
 
     expect(server.clients.size).toBe(0);
   });
+
+  it('should stop dispatching messages after completing a subscription', async () => {
+    const {
+      url,
+      server,
+      waitForOperation,
+      waitForComplete,
+    } = await startTServer();
+
+    const sub = tsubscribe(createClient({ url }), {
+      query: 'subscription { greetings }',
+    });
+    await waitForOperation();
+
+    for (const client of server.webSocketServer.clients) {
+      client.once('message', () => {
+        // no more messages from the client
+        fail("Shouldn't have dispatched a message");
+      });
+    }
+
+    await waitForComplete();
+    await sub.waitForComplete();
+  });
 });
 
 describe('"concurrency"', () => {

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -204,7 +204,7 @@ it('should close with error message during connecting issues', async () => {
 
 describe('query operation', () => {
   it('should execute the query, "next" the result and then complete', async () => {
-    const { url } = await startTServer();
+    const { url, ...server } = await startTServer();
 
     const client = createClient({ url });
 
@@ -217,6 +217,8 @@ describe('query operation', () => {
     });
 
     await sub.waitForComplete();
+
+    await server.waitForClientClose();
   });
 
   it('should accept nullish value for `operationName` and `variables`', async () => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1454,20 +1454,15 @@ describe('Subscribe', () => {
       }),
     );
 
-    // confirm complete
+    // wait for complete event to be processed
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    server.pong();
+    server.pong();
+    server.pong();
+
     await client.waitForMessage(({ data }) => {
-      expect(parseMessage(data)).toEqual({
-        id: '1',
-        type: MessageType.Complete,
-      });
-    });
-
-    server.pong();
-    server.pong();
-    server.pong();
-
-    await client.waitForMessage(() => {
-      fail('Shouldnt have received a message');
+      fail(`Shouldn't have received message ${data}`);
     }, 30);
   });
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1461,8 +1461,8 @@ describe('Subscribe', () => {
     server.pong();
     server.pong();
 
-    await client.waitForMessage(({ data }) => {
-      fail(`Shouldn't have received message ${data}`);
+    await client.waitForMessage(() => {
+      fail("Shouldn't have received a message");
     }, 30);
   });
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1446,7 +1446,7 @@ describe('Subscribe', () => {
       });
     });
 
-    // complete
+    // send complete
     client.ws.send(
       stringifyMessage<MessageType.Complete>({
         id: '1',
@@ -1454,8 +1454,7 @@ describe('Subscribe', () => {
       }),
     );
 
-    // wait for complete event to be processed
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await server.waitForComplete();
 
     server.pong();
     server.pong();


### PR DESCRIPTION
@enisdenjo  I noticed that the client logic was sending a Complete event back to server immediately after the Server had sent a Complete event for that same operation, so hopefully this is a valid change.