### PR TITLE
feat(client): `connectionParams` may return a promise

### DIFF
--- a/docs/interfaces/_client_.clientoptions.md
+++ b/docs/interfaces/_client_.clientoptions.md
@@ -4,7 +4,7 @@
 
 # Interface: ClientOptions
 
-Configuration used for the `create` client function.
+Configuration used for the GraphQL over WebSocket client.
 
 ## Hierarchy
 
@@ -28,11 +28,17 @@ Configuration used for the `create` client function.
 
 ### connectionParams
 
-• `Optional` **connectionParams**: Record\<string, unknown> \| () => Record\<string, unknown>
+• `Optional` **connectionParams**: Record\<string, unknown> \| () => Promise\<Record\<string, unknown>> \| Record\<string, unknown>
 
 Optional parameters, passed through the `payload` field with the `ConnectionInit` message,
 that the client specifies when establishing a connection with the server. You can use this
 for securely passing arguments for authentication.
+
+If you decide to return a promise, keep in mind that the server might kick you off if it
+takes too long to resolve! Check the `connectionInitWaitTimeout` on the server for more info.
+
+Throwing an error from within this function will close the socket with the `Error` message
+in the close event reason.
 
 ___
 

--- a/docs/modules/_client_.md
+++ b/docs/modules/_client_.md
@@ -97,7 +97,7 @@ Name | Type |
 
 ▸ **createClient**(`options`: [ClientOptions](../interfaces/_client_.clientoptions.md)): [Client](../interfaces/_client_.client.md)
 
-Creates a disposable GraphQL subscriptions client.
+Creates a disposable GraphQL over WebSocket client.
 
 #### Parameters:
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -332,26 +332,25 @@ export function createClient(options: ClientOptions): Client {
           return;
         }
 
-        Promise.resolve(
-          typeof connectionParams === 'function'
-            ? connectionParams()
-            : connectionParams,
-        )
-          .then((params) =>
+        (async () => {
+          try {
             socket.send(
               stringifyMessage<MessageType.ConnectionInit>({
                 type: MessageType.ConnectionInit,
-                payload: params,
+                payload:
+                  typeof connectionParams === 'function'
+                    ? await connectionParams()
+                    : connectionParams,
               }),
-            ),
-          )
-          .catch((err) =>
+            );
+          } catch (err) {
             // even if not open, call close again to report error
             socket.close(
               4400,
               err instanceof Error ? err.message : new Error(err).message,
-            ),
-          );
+            );
+          }
+        })();
       };
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -52,7 +52,7 @@ export type EventListener<E extends Event> = E extends EventConnecting
 
 type CancellerRef = { current: (() => void) | null };
 
-/** Configuration used for the `create` client function. */
+/** Configuration used for the GraphQL over WebSocket client. */
 export interface ClientOptions {
   /** URL of the GraphQL over WebSocket Protocol compliant server to connect. */
   url: string;
@@ -63,6 +63,9 @@ export interface ClientOptions {
    *
    * If you decide to return a promise, keep in mind that the server might kick you off if it
    * takes too long to resolve! Check the `connectionInitWaitTimeout` on the server for more info.
+   *
+   * Throwing an error from within this function will close the socket with the `Error` message
+   * in the close event reason.
    */
   connectionParams?:
     | Record<string, unknown>
@@ -133,7 +136,7 @@ export interface Client extends Disposable {
   subscribe<T = unknown>(payload: SubscribePayload, sink: Sink<T>): () => void;
 }
 
-/** Creates a disposable GraphQL subscriptions client. */
+/** Creates a disposable GraphQL over WebSocket client. */
 export function createClient(options: ClientOptions): Client {
   const {
     url,

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -202,6 +202,41 @@ it('should close with error message during connecting issues', async () => {
   });
 });
 
+it('should pass the `connectionParams` through', async () => {
+  let server = await startTServer();
+  createClient({
+    url: server.url,
+    lazy: false,
+    connectionParams: { auth: 'token' },
+  });
+  await server.waitForConnect((ctx) => {
+    expect(ctx.connectionParams).toEqual({ auth: 'token' });
+  });
+  await server.dispose();
+
+  server = await startTServer();
+  createClient({
+    url: server.url,
+    lazy: false,
+    connectionParams: () => ({ from: 'func' }),
+  });
+  await server.waitForConnect((ctx) => {
+    expect(ctx.connectionParams).toEqual({ from: 'func' });
+  });
+  await server.dispose();
+
+  server = await startTServer();
+  createClient({
+    url: server.url,
+    lazy: false,
+    connectionParams: () => Promise.resolve({ from: 'promise' }),
+  });
+  await server.waitForConnect((ctx) => {
+    expect(ctx.connectionParams).toEqual({ from: 'promise' });
+  });
+  await server.dispose();
+});
+
 describe('query operation', () => {
   it('should execute the query, "next" the result and then complete', async () => {
     const { url } = await startTServer();

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -203,8 +203,9 @@ it('should close with error message during connecting issues', async () => {
 });
 
 it('should pass the `connectionParams` through', async () => {
-  let server = await startTServer();
-  createClient({
+  const server = await startTServer();
+
+  let client = createClient({
     url: server.url,
     lazy: false,
     connectionParams: { auth: 'token' },
@@ -212,10 +213,9 @@ it('should pass the `connectionParams` through', async () => {
   await server.waitForConnect((ctx) => {
     expect(ctx.connectionParams).toEqual({ auth: 'token' });
   });
-  await server.dispose();
+  await client.dispose();
 
-  server = await startTServer();
-  createClient({
+  client = createClient({
     url: server.url,
     lazy: false,
     connectionParams: () => ({ from: 'func' }),
@@ -223,10 +223,9 @@ it('should pass the `connectionParams` through', async () => {
   await server.waitForConnect((ctx) => {
     expect(ctx.connectionParams).toEqual({ from: 'func' });
   });
-  await server.dispose();
+  await client.dispose();
 
-  server = await startTServer();
-  createClient({
+  client = createClient({
     url: server.url,
     lazy: false,
     connectionParams: () => Promise.resolve({ from: 'promise' }),
@@ -234,7 +233,6 @@ it('should pass the `connectionParams` through', async () => {
   await server.waitForConnect((ctx) => {
     expect(ctx.connectionParams).toEqual({ from: 'promise' });
   });
-  await server.dispose();
 });
 
 describe('query operation', () => {


### PR DESCRIPTION
Closes: #70 

**Beware:** if you decide to return a promise, [the server might kick you off if it takes too long to resolve](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#connectioninit)! You can either tune the promise or control the [server `connectionInitWaitTimeout`](https://github.com/enisdenjo/graphql-ws/blob/master/docs/interfaces/_server_.serveroptions.md#connectioninitwaittimeout).