### PR TITLE
feat(client): Retry with randomised exponential backoff or provide your own strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,33 @@ const link = new WebSocketLink({
 
 </details>
 
+<details id="retry-strategy">
+<summary><a href="#retry-strategy">🔗</a> Client usage with custom retry timeout strategy</summary>
+
+```typescript
+import { createClient } from 'graphql-ws';
+
+const client = createClient({
+  url: 'wss://i.want.retry/control/graphql',
+  // this is the default
+  retryWait: async function randomisedExponentialBackoff(retries: number) {
+    let retryDelay = 1000; // start with 1s delay
+    for (let i = 0; i < retries; i++) {
+      retryDelay *= 2; // square `retries` times
+    }
+    await new Promise((resolve) =>
+      setTimeout(
+        // resolve pending promise with added random timeout from 300ms to 3s
+        resolve,
+        retryDelay + Math.floor(Math.random() * (3000 - 300) + 300),
+      ),
+    );
+  },
+});
+```
+
+</details>
+
 <details id="browser">
 <summary><a href="#browser">🔗</a> Client usage in browser</summary>
 

--- a/docs/interfaces/_client_.clientoptions.md
+++ b/docs/interfaces/_client_.clientoptions.md
@@ -113,10 +113,10 @@ ___
 
 ### retryWait
 
-• `Optional` **retryWait**: undefined \| (tries: number) => Promise\<void>
+• `Optional` **retryWait**: undefined \| (retries: number) => Promise\<void>
 
 Control the wait time between retries. You may implement your own strategy
-by timing the resolution of the returned promise.
+by timing the resolution of the returned promise with the retries count.
 
 **`default`** Randomised exponential backoff
 

--- a/docs/interfaces/_client_.clientoptions.md
+++ b/docs/interfaces/_client_.clientoptions.md
@@ -20,6 +20,7 @@ Configuration used for the GraphQL over WebSocket client.
 * [lazy](_client_.clientoptions.md#lazy)
 * [on](_client_.clientoptions.md#on)
 * [retryAttempts](_client_.clientoptions.md#retryattempts)
+* [retryWait](_client_.clientoptions.md#retrywait)
 * [url](_client_.clientoptions.md#url)
 * [webSocketImpl](_client_.clientoptions.md#websocketimpl)
 
@@ -107,6 +108,17 @@ The library classifies the following close events as fatal:
 These events are reported immediately and the client will not reconnect.
 
 **`default`** 5
+
+___
+
+### retryWait
+
+• `Optional` **retryWait**: undefined \| (tries: number) => Promise\<void>
+
+Control the wait time between retries. You may implement your own strategy
+by timing the resolution of the returned promise.
+
+**`default`** Randomised exponential backoff
 
 ___
 

--- a/docs/interfaces/_client_.clientoptions.md
+++ b/docs/interfaces/_client_.clientoptions.md
@@ -20,7 +20,6 @@ Configuration used for the GraphQL over WebSocket client.
 * [lazy](_client_.clientoptions.md#lazy)
 * [on](_client_.clientoptions.md#on)
 * [retryAttempts](_client_.clientoptions.md#retryattempts)
-* [retryTimeout](_client_.clientoptions.md#retrytimeout)
 * [url](_client_.clientoptions.md#url)
 * [webSocketImpl](_client_.clientoptions.md#websocketimpl)
 
@@ -108,16 +107,6 @@ The library classifies the following close events as fatal:
 These events are reported immediately and the client will not reconnect.
 
 **`default`** 5
-
-___
-
-### retryTimeout
-
-• `Optional` **retryTimeout**: undefined \| number
-
-How long should the client wait until attempting to retry.
-
-**`default`** 3 * 1000 (3 seconds)
 
 ___
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -103,11 +103,11 @@ export interface ClientOptions {
   retryAttempts?: number;
   /**
    * Control the wait time between retries. You may implement your own strategy
-   * by timing the resolution of the returned promise.
+   * by timing the resolution of the returned promise with the retries count.
    *
    * @default Randomised exponential backoff
    */
-  retryWait?: (tries: number) => Promise<void>;
+  retryWait?: (retries: number) => Promise<void>;
   /**
    * Register listeners before initialising the client. This way
    * you can ensure to catch all client relevant emitted events.

--- a/src/client.ts
+++ b/src/client.ts
@@ -290,13 +290,15 @@ export function createClient(options: ClientOptions): Client {
       }
     }
 
+    // if recursive call, wait a bit for socket change
+    await new Promise((resolve) => setTimeout(resolve, callDepth * 50));
+
     // socket already exists. can be ready or pending, check and behave accordingly
     if (state.socket) {
       switch (state.socket.readyState) {
         case WebSocketImpl.OPEN: {
           // if the socket is not acknowledged, wait a bit and reavaluate
           if (!state.acknowledged) {
-            await new Promise((resolve) => setTimeout(resolve, 300));
             return connect(cancellerRef, callDepth + 1);
           }
 
@@ -304,14 +306,12 @@ export function createClient(options: ClientOptions): Client {
         }
         case WebSocketImpl.CONNECTING: {
           // if the socket is in the connecting phase, wait a bit and reavaluate
-          await new Promise((resolve) => setTimeout(resolve, 300));
           return connect(cancellerRef, callDepth + 1);
         }
         case WebSocketImpl.CLOSED:
           break; // just continue, we'll make a new one
         case WebSocketImpl.CLOSING: {
           // if the socket is in the closing phase, wait a bit and connect
-          await new Promise((resolve) => setTimeout(resolve, 300));
           return connect(cancellerRef, callDepth + 1);
         }
         default:

--- a/src/client.ts
+++ b/src/client.ts
@@ -276,7 +276,7 @@ export function createClient(options: ClientOptions): Client {
     if (state.retrying && callDepth === 0) {
       if (retryWaiting.length) {
         // if others are waiting for retry, I'll wait too
-        await new Promise((resolve) => retryWaiting.push(resolve));
+        await new Promise<void>((resolve) => retryWaiting.push(resolve));
       } else {
         retryWaiting.push(() => {
           /** fake waiter to lead following connects in the `retryWaiting` queue */

--- a/src/client.ts
+++ b/src/client.ts
@@ -282,7 +282,7 @@ export function createClient(options: ClientOptions): Client {
           /** fake waiter to lead following connects in the `retryWaiting` queue */
         });
         // use retry wait strategy
-        await retryWait(state.retries);
+        await retryWait(state.retries++);
         // complete all waiting and clear the queue
         while (retryWaiting.length) {
           retryWaiting.pop()?.();
@@ -325,7 +325,6 @@ export function createClient(options: ClientOptions): Client {
       ...state,
       acknowledged: false,
       socket,
-      retries: state.retrying ? state.retries + 1 : state.retries,
     };
     emitter.emit('connecting');
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,12 +155,9 @@ export function createClient(options: ClientOptions): Client {
     lazy = true,
     keepAlive = 0,
     retryAttempts = 5,
-    /**
-     * Retry with randomised exponential backoff.
-     */
-    retryWait = async function retryWait(tries) {
-      let retryDelay = 1000; // 1s
-      for (let i = 0; i < tries; i++) {
+    retryWait = async function randomisedExponentialBackoff(retries) {
+      let retryDelay = 1000; // start with 1s delay
+      for (let i = 0; i < retries; i++) {
         retryDelay *= 2;
       }
       await new Promise((resolve) =>

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -664,21 +664,30 @@ describe('reconnecting', () => {
   it('should reconnect silently after socket closes', async () => {
     const { url, ...server } = await startTServer();
 
-    const sub = tsubscribe(
-      createClient({
-        url,
-        retryAttempts: 1,
-      }),
-      {
-        query: 'subscription { ping }',
-      },
-    );
+    const client = createClient({
+      url,
+      retryAttempts: 3,
+      retryWait: () => Promise.resolve(),
+    });
+    const sub = tsubscribe(client, {
+      query: 'subscription { ping }',
+    });
 
     await server.waitForClient((client) => {
       client.close();
     });
 
-    // tried again
+    // retried
+    await server.waitForClient((client) => {
+      client.close();
+    });
+
+    // once more
+    await server.waitForClient((client) => {
+      client.close();
+    });
+
+    // and once more
     await server.waitForClient((client) => {
       client.close();
     });

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -644,7 +644,6 @@ describe('reconnecting', () => {
       createClient({
         url,
         retryAttempts: 0,
-        retryTimeout: 5, // fake timeout
       }),
       {
         query: 'subscription { ping }',
@@ -655,14 +654,11 @@ describe('reconnecting', () => {
       client.close();
     });
 
-    await server.waitForClient(() => {
-      fail('Shouldnt have tried again');
-    }, 20);
-
-    // client reported the error
+    // client reported the error immediately, meaning it wont retry
+    expect.assertions(1);
     await sub.waitForError((err) => {
       expect((err as CloseEvent).code).toBe(1005);
-    });
+    }, 20);
   });
 
   it('should reconnect silently after socket closes', async () => {
@@ -672,7 +668,6 @@ describe('reconnecting', () => {
       createClient({
         url,
         retryAttempts: 1,
-        retryTimeout: 5,
       }),
       {
         query: 'subscription { ping }',
@@ -688,15 +683,11 @@ describe('reconnecting', () => {
       client.close();
     });
 
-    // never again
-    await server.waitForClient(() => {
-      fail('Shouldnt have tried again');
-    }, 20);
-
-    // client reported the error
+    // client reported the error, meaning it wont retry anymore
+    expect.assertions(1);
     await sub.waitForError((err) => {
       expect((err as CloseEvent).code).toBe(1005);
-    });
+    }, 20);
   });
 
   it('should report some close events immediately and not reconnect', async () => {
@@ -707,7 +698,6 @@ describe('reconnecting', () => {
         createClient({
           url,
           retryAttempts: Infinity, // keep retrying forever
-          retryTimeout: 5,
         }),
         {
           query: 'subscription { ping }',
@@ -718,16 +708,13 @@ describe('reconnecting', () => {
         client.close(code);
       });
 
-      await server.waitForClient(() => {
-        fail('Shouldnt have tried again');
-      }, 20);
-
-      // client reported the error
+      // client reported the error immediately, meaning it wont retry
       await sub.waitForError((err) => {
         expect((err as CloseEvent).code).toBe(code);
-      });
+      }, 20);
     }
 
+    expect.assertions(6);
     await testCloseCode(1002);
     await testCloseCode(1011);
     await testCloseCode(4400);


### PR DESCRIPTION
Closes: #80 

### Breaking change
Client `retryTimeout` option has been replaced with the new `retryWait`. It allows you to control the retry timeout strategy by resolving the returned promise when ready. The default implement the randomised exponential backoff like so:
```ts
// this is the default
const retryWait = async function randomisedExponentialBackoff(retries: number) {
  let retryDelay = 1000; // start with 1s delay
  for (let i = 0; i < retries; i++) {
    retryDelay *= 2; // square `retries` times
  }
  await new Promise((resolve) =>
    setTimeout(
      // resolve pending promise with added random timeout from 300ms to 3s
      resolve,
      retryDelay + Math.floor(Math.random() * (3000 - 300) + 300),
    ),
  );
};
```

### TODO
- [x] Implement `retryWait(retries: number): Promise<void>` for retry wait strategy control
- [x] Add usage recipe