### PR TITLE
feat: log warning in dev when using incorrect protocol

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,12 @@ import {
   ErrorMessage,
   CompleteMessage,
 } from './message';
-import { isObject, isAsyncIterable, areGraphQLErrors } from './utils';
+import {
+  isObject,
+  isAsyncIterable,
+  areGraphQLErrors,
+  logDeveloperWarning,
+} from './utils';
 import { ID } from './types';
 
 export type OperationResult =
@@ -398,6 +403,11 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
     opened(socket, extra) {
       if (socket.protocol !== GRAPHQL_TRANSPORT_WS_PROTOCOL) {
         socket.close(1002, 'Protocol Error');
+        logDeveloperWarning(
+          `Invalid protocol: '${socket.protocol}'. 
+          Only ${GRAPHQL_TRANSPORT_WS_PROTOCOL} is supported.
+          For more details see https://github.com/enisdenjo/graphql-ws/issues/83`,
+        );
         return async () => {
           /* nothing was set up */
         };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,9 @@ export function hasOwnStringProperty<
 >(obj: O, prop: P): obj is O & Record<P, string> {
   return baseHasOwnProperty.call(obj, prop) && typeof obj[prop] === 'string';
 }
+
+export function logDeveloperWarning(msg: string): void {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`[graphql-ws] ${msg}`);
+  }
+}


### PR DESCRIPTION
I was integrating graphql-ws for a hackathon at work and it took me ages to figure out that the problem was I was trying to test with [Altair](https://chrome.google.com/webstore/detail/altair-graphql-client/flnheeellpciglgpaodhkhmapeljopja), a nice GraphiQL-like extension that looked like it supported extensions, but uses the `graphql-ws` protocol. The fact that it fails somewhat silently added time. I eventually found #83 and understood why it's not supported.

Adding a warning in dev mode to help folks like me figure out this faster since the ecosystem is a bit messy for a new person.

### Example Screenshot

![](https://drive.google.com/uc?id=1VADlTcAoXaio2YPXTKBCNg9nvV59If5t)

Thanks for considering it.