### PR TITLE
feat(server): Add `onDisconnect` callback

### DIFF
--- a/docs/interfaces/_server_.server.md
+++ b/docs/interfaces/_server_.server.md
@@ -35,8 +35,9 @@ of the `Context`. You may pass the initial request or the
 original WebSocket, if you need it down the road.
 
 Returns a function that should be called when the same socket
-has been closed, for whatever reason. The returned promise will
-resolve once the internal cleanup is complete.
+has been closed, for whatever reason. The close code and reason
+must be passed for reporting to the `onDisconnect` callback. Returned
+promise will resolve once the internal cleanup is complete.
 
 #### Parameters:
 

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -23,6 +23,7 @@ Name | Default |
 * [execute](_server_.serveroptions.md#execute)
 * [onComplete](_server_.serveroptions.md#oncomplete)
 * [onConnect](_server_.serveroptions.md#onconnect)
+* [onDisconnect](_server_.serveroptions.md#ondisconnect)
 * [onError](_server_.serveroptions.md#onerror)
 * [onNext](_server_.serveroptions.md#onnext)
 * [onOperation](_server_.serveroptions.md#onoperation)
@@ -127,6 +128,17 @@ field in the `ConnectionAck` message.
 Throwing an error from within this function will
 close the socket with the `Error` message
 in the close event reason.
+
+___
+
+### onDisconnect
+
+• `Optional` **onDisconnect**: undefined \| (ctx: [Context](_server_.context.md)<E\>, code: number, reason: string) => Promise<void\> \| void
+
+Called when the socket/client closes/disconnects for
+whatever reason. Provides the close event too. Beware
+that this callback happens AFTER all subscriptions have
+been gracefuly completed.
 
 ___
 

--- a/docs/interfaces/_server_.serveroptions.md
+++ b/docs/interfaces/_server_.serveroptions.md
@@ -140,6 +140,9 @@ whatever reason. Provides the close event too. Beware
 that this callback happens AFTER all subscriptions have
 been gracefuly completed.
 
+If you are interested in tracking the subscriptions completions,
+consider using the `onComplete` callback.
+
 ___
 
 ### onError

--- a/docs/interfaces/_server_.websocket.md
+++ b/docs/interfaces/_server_.websocket.md
@@ -36,7 +36,8 @@ to validate agains the supported ones.
 ▸ **close**(`code`: number, `reason`: string): Promise<void\> \| void
 
 Closes the socket gracefully. Will always provide
-the appropriate code and close reason.
+the appropriate code and close reason. `onDisconnect`
+callback will be called.
 
 The returned promise is used to control the graceful
 closure.

--- a/src/server.ts
+++ b/src/server.ts
@@ -168,6 +168,9 @@ export interface ServerOptions<E = unknown> {
    * whatever reason. Provides the close event too. Beware
    * that this callback happens AFTER all subscriptions have
    * been gracefuly completed.
+   *
+   * If you are interested in tracking the subscriptions completions,
+   * consider using the `onComplete` callback.
    */
   onDisconnect?: (
     ctx: Context<E>,

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1383,3 +1383,26 @@ describe('Subscribe', () => {
     client.ws.terminate();
   });
 });
+
+describe('Disconnect', () => {
+  it('should report close code and reason to disconnect callback', async (done) => {
+    const { url, waitForConnect } = await startTServer({
+      onDisconnect: (_ctx, code, reason) => {
+        expect(code).toBe(4321);
+        expect(reason).toBe('Byebye');
+        done();
+      },
+    });
+
+    const client = await createTClient(url);
+
+    client.ws.send(
+      stringifyMessage<MessageType.ConnectionInit>({
+        type: MessageType.ConnectionInit,
+      }),
+    );
+    await waitForConnect();
+
+    client.ws.close(4321, 'Byebye');
+  });
+});

--- a/src/use/ws.ts
+++ b/src/use/ws.ts
@@ -105,10 +105,10 @@ export function useServer(
       { socket, request },
     );
 
-    socket.once('close', () => {
+    socket.once('close', (code, reason) => {
       if (pongWait) clearTimeout(pongWait);
       if (pingInterval) clearInterval(pingInterval);
-      closed();
+      closed(code, reason);
     });
   });
 


### PR DESCRIPTION
Closes: #91

### Breaking change

The return function of `server.opened` (`closed`) now requires the close event code and reason for reporting to the `onDisconnect` callback.

### TODO

- [x] Tests