### PR TITLE
fix(server): Enforce ID uniqueness across all operations and during the whole subscription life

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -62,7 +62,7 @@ Direction: **Client -> Server**
 
 Requests an operation specified in the message `payload`. This message provides a unique ID field to connect published messages to the operation requested by this message.
 
-If there is already an active subscriber for a streaming operation matching the provided ID, the server will close the socket immediately with the event `4409: Subscriber for <unique-operation-id> already exists`. The server may not assert this rule for operations returning a single result as they do not require reservations for additional future events.
+If there is already an active subscriber for an operation matching the provided ID, regardless of the operation type, the server must close the socket immediately with the event `4409: Subscriber for <unique-operation-id> already exists`.
 
 ```typescript
 interface SubscribeMessage {

--- a/docs/interfaces/_server_.context.md
+++ b/docs/interfaces/_server_.context.md
@@ -66,8 +66,12 @@ ___
 
 ### subscriptions
 
-• `Readonly` **subscriptions**: Record<[ID](../modules/_types_.md#id), AsyncIterator<unknown\>\>
+• `Readonly` **subscriptions**: Record<[ID](../modules/_types_.md#id), AsyncIterator<unknown\> \| Promise<void\>\>
 
-Holds the active subscriptions for this context.
-Subscriptions are for **streaming operations only**,
-those that resolve once wont be added here.
+Holds the active subscriptions for this context. **All operations**
+that are taking place are aggregated here. The user is _subscribed_
+to the operation waiting for the result(s).
+
+If the subscription behind an ID is an `AsyncIterator` - the operation
+is streaming; on the contrary, if the subscription is a `Promise` - the
+operation resolves to a single result or is still pending/being prepared.

--- a/docs/interfaces/_server_.context.md
+++ b/docs/interfaces/_server_.context.md
@@ -70,7 +70,7 @@ ___
 
 Holds the active subscriptions for this context. **All operations**
 that are taking place are aggregated here. The user is _subscribed_
-to the operation waiting for the result(s).
+to an operation when waiting for result(s).
 
 If the subscription behind an ID is an `AsyncIterator` - the operation
 is streaming; on the contrary, if the subscription is a `Promise` - the

--- a/docs/interfaces/_server_.context.md
+++ b/docs/interfaces/_server_.context.md
@@ -66,12 +66,13 @@ ___
 
 ### subscriptions
 
-• `Readonly` **subscriptions**: Record<[ID](../modules/_types_.md#id), AsyncIterator<unknown\> \| Promise<void\>\>
+• `Readonly` **subscriptions**: Record<[ID](../modules/_types_.md#id), AsyncIterator<unknown\> \| null\>
 
 Holds the active subscriptions for this context. **All operations**
 that are taking place are aggregated here. The user is _subscribed_
 to an operation when waiting for result(s).
 
 If the subscription behind an ID is an `AsyncIterator` - the operation
-is streaming; on the contrary, if the subscription is a `Promise` - the
-operation resolves to a single result or is still pending/being prepared.
+is streaming; on the contrary, if the subscription is `null` - it is simply
+a reservation, meaning - the operation resolves to a single result or is still
+pending/being prepared.

--- a/src/server.ts
+++ b/src/server.ts
@@ -359,11 +359,15 @@ export interface Context<E = unknown> {
   /** The parameters passed during the connection initialisation. */
   readonly connectionParams?: Readonly<Record<string, unknown>>;
   /**
-   * Holds the active subscriptions for this context.
-   * Subscriptions are for **streaming operations only**,
-   * those that resolve once wont be added here.
+   * Holds the active subscriptions for this context. **All operations**
+   * that are taking place are aggregated here. The user is _subscribed_
+   * to the operation waiting for the result(s).
+   *
+   * If the subscription behind an ID is an `AsyncIterator` - the operation
+   * is streaming; on the contrary, if the subscription is a `Promise` - the
+   * operation resolves to a single result or is still pending/being prepared.
    */
-  readonly subscriptions: Record<ID, AsyncIterator<unknown>>;
+  readonly subscriptions: Record<ID, AsyncIterator<unknown> | Promise<void>>;
   /**
    * An extra field where you can store your own context values
    * to pass between callbacks.
@@ -470,6 +474,19 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
             }
 
             const id = message.id;
+            if (ctx.subscriptions[id]) {
+              return socket.close(4409, `Subscriber for ${id} already exists`);
+            }
+
+            // if this turns out to be a streaming operation, the subscription value
+            // will change to an `AsyncIterable`, otherwise it will stay as is
+            let done = () => {
+              /* placeholder noop function to calm typescript down */
+            };
+            ctx.subscriptions[id] = new Promise<void>(
+              (resolve) => (done = resolve),
+            );
+
             const emit = {
               next: async (result: ExecutionResult, args: ExecutionArgs) => {
                 let nextMessage: NextMessage = {
@@ -610,34 +627,25 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
 
             if (isAsyncIterable(operationResult)) {
               /** multiple emitted results */
-
-              // iterable subscriptions are distinct on ID
-              if (ctx.subscriptions[id]) {
-                return socket.close(
-                  4409,
-                  `Subscriber for ${id} already exists`,
-                );
-              }
               ctx.subscriptions[id] = operationResult;
-
               for await (const result of operationResult) {
                 await emit.next(result, execArgs);
               }
-
-              // lack of subscription at this point indicates that the client
-              // completed the stream, he doesnt need to be reminded
-              await emit.complete(Boolean(ctx.subscriptions[id]));
-              delete ctx.subscriptions[id];
             } else {
               /** single emitted result */
-
               await emit.next(operationResult, execArgs);
-              await emit.complete(true);
             }
+
+            // lack of subscription at this point indicates that the client
+            // completed the subscription, he doesnt need to be reminded
+            await emit.complete(Boolean(ctx.subscriptions[id]));
+            delete ctx.subscriptions[id];
+            done();
             break;
           }
           case MessageType.Complete: {
-            await ctx.subscriptions[message.id]?.return?.();
+            const subscription = ctx.subscriptions[message.id];
+            if (isAsyncIterable(subscription)) await subscription.return?.();
             delete ctx.subscriptions[message.id]; // deleting the subscription means no further action
             break;
           }
@@ -652,7 +660,7 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
       return async () => {
         if (connectionInitWait) clearTimeout(connectionInitWait);
         for (const sub of Object.values(ctx.subscriptions)) {
-          await sub.return?.();
+          if (isAsyncIterable(sub)) await sub.return?.();
         }
       };
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -361,7 +361,7 @@ export interface Context<E = unknown> {
   /**
    * Holds the active subscriptions for this context. **All operations**
    * that are taking place are aggregated here. The user is _subscribed_
-   * to the operation waiting for the result(s).
+   * to an operation when waiting for result(s).
    *
    * If the subscription behind an ID is an `AsyncIterator` - the operation
    * is streaming; on the contrary, if the subscription is a `Promise` - the

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1101,7 +1101,7 @@ describe('Subscribe', () => {
     }, 30);
   });
 
-  it('should close the socket on duplicate `subscription` operation subscriptions request', async () => {
+  it.only('should close the socket on duplicate operation requests', async () => {
     const { url } = await startTServer();
 
     const client = await createTClient(url);
@@ -1130,7 +1130,7 @@ describe('Subscribe', () => {
         id: 'not-unique',
         type: MessageType.Subscribe,
         payload: {
-          query: 'subscription { greetings }',
+          query: 'query { getValue }',
         },
       }),
     );

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1101,7 +1101,7 @@ describe('Subscribe', () => {
     }, 30);
   });
 
-  it.only('should close the socket on duplicate operation requests', async () => {
+  it('should close the socket on duplicate operation requests', async () => {
     const { url } = await startTServer();
 
     const client = await createTClient(url);


### PR DESCRIPTION
Closes: #95

### Breaking change

The `Context.subscriptions` record can hold either an `AsyncIterator` or `Promise` value.