### PR TITLE
fix(exports): solve 'No "exports" main defined'

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "exports": {
-    "./": {
+    ".": {
       "require": "./lib/index.js",
       "import": "./lib/index.mjs"
     },


### PR DESCRIPTION
In a new folder (Node v14.11.0):

```
yarn add postgraphile
yarn postgraphile -c my_db
```

Result:

```
No "exports" main defined in [cwd]/node_modules/graphql-ws/package.json
```

Dropping this single character seems to resolve the issue.

Inspired by the "Package entry points" documentation in Node.js: https://nodejs.org/api/packages.html#packages_package_entry_points