### PR TITLE
feat(client): `isFatalConnectionProblem` option for deciding if the connect error should be immediately reported or the connection retried

### DIFF
--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -66,14 +66,11 @@ been exceeded.
 The argument is either a WebSocket `CloseEvent` or an error thrown during
 the connection phase.
 
-**`default`** 
-Non close events and the following close events are fatal:
-- `1002: Protocol Error`
-- `1011: Internal Error`
-- `4400: Bad Request`
-- `4401: Unauthorized` _tried subscribing before connect ack_
-- `4409: Subscriber for <id> already exists` _distinction is very important_
-- `4429: Too many initialisation requests`
+Beware, the library classifies a few close events as fatal regardless of
+what is returned. They are listed in the documentation of the `retryAttempts`
+option.
+
+**`default`** Non close events
 
 ___
 
@@ -141,6 +138,16 @@ ___
 • `Optional` **retryAttempts**: *undefined* \| *number*
 
 How many times should the client try to reconnect on abnormal socket closure before it errors out?
+
+The library classifies the following close events as fatal:
+- `1002: Protocol Error`
+- `1011: Internal Error`
+- `4400: Bad Request`
+- `4401: Unauthorized` _tried subscribing before connect ack_
+- `4409: Subscriber for <id> already exists` _distinction is very important_
+- `4429: Too many initialisation requests`
+
+These events are reported immediately and the client will not reconnect.
 
 **`default`** 5
 

--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -63,6 +63,9 @@ the client will fail immediately without additional retries; however, if you
 return `false`, the client will keep retrying until the `retryAttempts` have
 been exceeded.
 
+The argument is either a WebSocket `CloseEvent` or an error thrown during
+the connection phase.
+
 **`default`** 
 Non close events and the following close events are fatal:
 - `1002: Protocol Error`

--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -12,6 +12,7 @@ Configuration used for the GraphQL over WebSocket client.
 
 - [connectionParams](client.clientoptions.md#connectionparams)
 - [generateID](client.clientoptions.md#generateid)
+- [isFatalConnectionProblem](client.clientoptions.md#isfatalconnectionproblem)
 - [keepAlive](client.clientoptions.md#keepalive)
 - [lazy](client.clientoptions.md#lazy)
 - [on](client.clientoptions.md#on)
@@ -50,6 +51,26 @@ as the random number generator. Supply your own generator
 in case you need more uniqueness.
 
 Reference: https://stackoverflow.com/a/2117523/709884
+
+___
+
+### isFatalConnectionProblem
+
+• `Optional` **isFatalConnectionProblem**: *undefined* \| (`errOrCloseEvent`: *unknown*) => *boolean*
+
+Check if the close event or connection error is fatal. If you return `true`,
+the client will fail immediately without additional retries; however, if you
+return `false`, the client will keep retrying until the `retryAttempts` have
+been exceeded.
+
+**`default`** 
+Non close events and the following close events are fatal:
+- `1002: Protocol Error`
+- `1011: Internal Error`
+- `4400: Bad Request`
+- `4401: Unauthorized` _tried subscribing before connect ack_
+- `4409: Subscriber for <id> already exists` _distinction is very important_
+- `4429: Too many initialisation requests`
 
 ___
 
@@ -117,16 +138,6 @@ ___
 • `Optional` **retryAttempts**: *undefined* \| *number*
 
 How many times should the client try to reconnect on abnormal socket closure before it errors out?
-
-The library classifies the following close events as fatal:
-- `1002: Protocol Error`
-- `1011: Internal Error`
-- `4400: Bad Request`
-- `4401: Unauthorized` _tried subscribing before connect ack_
-- `4409: Subscriber for <id> already exists` _distinction is very important_
-- `4429: Too many initialisation requests`
-
-These events are reported immediately and the client will not reconnect.
 
 **`default`** 5
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -110,6 +110,16 @@ export interface ClientOptions {
   /**
    * How many times should the client try to reconnect on abnormal socket closure before it errors out?
    *
+   * The library classifies the following close events as fatal:
+   * - `1002: Protocol Error`
+   * - `1011: Internal Error`
+   * - `4400: Bad Request`
+   * - `4401: Unauthorized` _tried subscribing before connect ack_
+   * - `4409: Subscriber for <id> already exists` _distinction is very important_
+   * - `4429: Too many initialisation requests`
+   *
+   * These events are reported immediately and the client will not reconnect.
+   *
    * @default 5
    */
   retryAttempts?: number;
@@ -131,14 +141,11 @@ export interface ClientOptions {
    * The argument is either a WebSocket `CloseEvent` or an error thrown during
    * the connection phase.
    *
-   * @default
-   * Non close events and the following close events are fatal:
-   * - `1002: Protocol Error`
-   * - `1011: Internal Error`
-   * - `4400: Bad Request`
-   * - `4401: Unauthorized` _tried subscribing before connect ack_
-   * - `4409: Subscriber for <id> already exists` _distinction is very important_
-   * - `4429: Too many initialisation requests`
+   * Beware, the library classifies a few close events as fatal regardless of
+   * what is returned. They are listed in the documentation of the `retryAttempts`
+   * option.
+   *
+   * @default Non close events
    */
   isFatalConnectionProblem?: (errOrCloseEvent: unknown) => boolean;
   /**
@@ -204,17 +211,8 @@ export function createClient(options: ClientOptions): Client {
       );
     },
     isFatalConnectionProblem = (errOrCloseEvent) =>
-      // non `CloseEvent`s are fatal by nature
-      !isLikeCloseEvent(errOrCloseEvent) ||
-      // some close codes are worth reporting immediately
-      [
-        1002, // Protocol Error
-        1011, // Internal Error
-        4400, // Bad Request
-        4401, // Unauthorized (tried subscribing before connect ack)
-        4409, // Subscriber for <id> already exists (distinction is very important)
-        4429, // Too many initialisation requests
-      ].includes(errOrCloseEvent.code),
+      // non `CloseEvent`s are fatal by default
+      !isLikeCloseEvent(errOrCloseEvent),
     on,
     webSocketImpl,
     /**
@@ -392,8 +390,18 @@ export function createClient(options: ClientOptions): Client {
    * Checks the `connect` problem and evaluates if the client should retry.
    */
   function shouldRetryConnectOrThrow(errOrCloseEvent: unknown): boolean {
-    // throw fatal connection problems immediately
-    if (isFatalConnectionProblem(errOrCloseEvent)) {
+    // some close codes are worth reporting immediately
+    if (
+      isLikeCloseEvent(errOrCloseEvent) &&
+      [
+        1002, // Protocol Error
+        1011, // Internal Error
+        4400, // Bad Request
+        4401, // Unauthorized (tried subscribing before connect ack)
+        4409, // Subscriber for <id> already exists (distinction is very important)
+        4429, // Too many initialisation requests
+      ].includes(errOrCloseEvent.code)
+    ) {
       throw errOrCloseEvent;
     }
 
@@ -407,6 +415,11 @@ export function createClient(options: ClientOptions): Client {
 
     // retries are not allowed or we tried to many times, report error
     if (!retryAttempts || retries >= retryAttempts) {
+      throw errOrCloseEvent;
+    }
+
+    // throw fatal connection problems immediately
+    if (isFatalConnectionProblem(errOrCloseEvent)) {
       throw errOrCloseEvent;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -128,6 +128,9 @@ export interface ClientOptions {
    * return `false`, the client will keep retrying until the `retryAttempts` have
    * been exceeded.
    *
+   * The argument is either a WebSocket `CloseEvent` or an error thrown during
+   * the connection phase.
+   *
    * @default
    * Non close events and the following close events are fatal:
    * - `1002: Protocol Error`


### PR DESCRIPTION
Closes: #122

Introduces a new, optional, `isFatalConnectionProblem(errOrCloseEvent: unknown): boolean` client option for giving the user power to decide if the client should retry.

By default all non close events fatal.

**Beware**, the following close events are fatal regardless:
- `1002: Protocol Error`
- `1011: Internal Error`
- `4400: Bad Request`
- `4401: Unauthorized` _tried subscribing before connect ack_
- `4409: Subscriber for <id> already exists` _distinction is very important_
- `4429: Too many initialisation requests`