### PR TITLE
fix(client): New `error` event listener for handling connection errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -305,14 +305,14 @@ export function createClient(options: ClientOptions): Client {
           emitter.emit('connecting');
           const socket = new WebSocketImpl(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
 
+          // in case of a connection error, onerror will be called first and then onclose (will always follow)
+          socket.onerror = reject;
+
           socket.onclose = (event) => {
             connecting = undefined;
             emitter.emit('closed', event);
             reject(event);
           };
-
-          // even with onerror, onclose will be always called after
-          socket.onerror = reject;
 
           socket.onopen = async () => {
             try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -311,6 +311,9 @@ export function createClient(options: ClientOptions): Client {
             reject(event);
           };
 
+          // even with onerror, onclose will be always called after
+          socket.onerror = reject;
+
           socket.onopen = async () => {
             try {
               socket.send(

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -325,6 +325,57 @@ it('should not send the complete message if the socket is not open', async () =>
   await sub.waitForComplete();
 });
 
+it('should pass the emitted websocket connection error to non-lazy error handler', (done) => {
+  expect.assertions(3);
+  createClient({
+    url: 'ws://localhost/i/dont/exist',
+    lazy: false,
+    retryAttempts: 0,
+    onNonLazyError: (err) => {
+      expect(err).toHaveProperty('message');
+      expect((err as ErrorEvent).message).toBe(
+        'connect ECONNREFUSED 127.0.0.1:80',
+      );
+      done();
+    },
+    on: {
+      closed: (err) => {
+        // even though error is thrown, dispatch a close event
+        expect((err as CloseEvent).code).toBe(1006);
+      },
+    },
+  });
+});
+
+it("should pass the emitted websocket connection error to the subscriber's sink", (done) => {
+  expect.assertions(3);
+
+  const client = createClient({
+    url: 'ws://localhost/i/dont/exist',
+    retryAttempts: 0,
+  });
+
+  client.on('closed', (err) => {
+    // even though error is thrown, dispatch a close event
+    expect((err as CloseEvent).code).toBe(1006);
+  });
+
+  client.subscribe(
+    { query: '' },
+    {
+      next: noop,
+      complete: noop,
+      error: (err) => {
+        expect(err).toHaveProperty('message');
+        expect((err as ErrorEvent).message).toBe(
+          'connect ECONNREFUSED 127.0.0.1:80',
+        );
+        done();
+      },
+    },
+  );
+});
+
 describe('query operation', () => {
   it('should execute the query, "next" the result and then complete', async () => {
     const { url } = await startTServer();


### PR DESCRIPTION
Closes #135 