### PR TITLE
feat(client): `url` option accepts a function or a Promise

### DIFF
--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -213,9 +213,12 @@ ___
 
 ### url
 
-• **url**: *string*
+• **url**: *string* \| (() => *Promise*<*string*> | <*string*>)
 
 URL of the GraphQL over WebSocket Protocol compliant server to connect.
+
+The case of returning a Promise can be used together with automatic reconnect upon abnormal
+socket closure if you need your url to be dynamically changing each time it reconnects. 
 
 ___
 

--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -213,12 +213,17 @@ ___
 
 ### url
 
-• **url**: *string* \| (() => *Promise*<*string*> | <*string*>)
+• **url**: *string* \| () => *string* \| *Promise*<string\>
 
 URL of the GraphQL over WebSocket Protocol compliant server to connect.
 
-The case of returning a Promise can be used together with automatic reconnect upon abnormal
-socket closure if you need your url to be dynamically changing each time it reconnects. 
+If the option is a function, it will be called on every WebSocket connection attempt.
+Returning a promise is supported too and the connecting phase will stall until it
+resolves with the URL.
+
+A good use-case for having a function is when using the URL for authentication,
+where subsequent reconnects (due to auth) may have a refreshed identity token in
+the URL.
 
 ___
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -335,10 +335,9 @@ export function createClient(options: ClientOptions): Client {
 
           emitter.emit('connecting');
           const socket = new WebSocketImpl(
-              typeof url === 'function'
-                  ? await url()
-                  : url,
-              GRAPHQL_TRANSPORT_WS_PROTOCOL);
+            typeof url === 'function' ? await url() : url,
+            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+          );
 
           socket.onerror = (err) => {
             // we let the onclose reject the promise for correct retry handling

--- a/src/client.ts
+++ b/src/client.ts
@@ -81,10 +81,16 @@ export type EventListener<E extends Event> = E extends EventConnecting
 
 /** Configuration used for the GraphQL over WebSocket client. */
 export interface ClientOptions {
-  /** URL of the GraphQL over WebSocket Protocol compliant server to connect.
+  /**
+   * URL of the GraphQL over WebSocket Protocol compliant server to connect.
    *
-   * The case of returning a Promise can be used together with automatic reconnect upon abnormal
-   * socket closure if you need your url to be dynamically changing each time it reconnects.
+   * If the option is a function, it will be called on every WebSocket connection attempt.
+   * Returning a promise is supported too and the connecting phase will stall until it
+   * resolves with the URL.
+   *
+   * A good use-case for having a function is when using the URL for authentication,
+   * where subsequent reconnects (due to auth) may have a refreshed identity token in
+   * the URL.
    */
   url: string | (() => Promise<string> | string);
   /**

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -140,6 +140,24 @@ it('should use the provided WebSocket implementation', async () => {
   await server.waitForClient();
 });
 
+it('should use the provided WebSocket implementation with url as a function that returns a Promise', async () => {
+  const { url, ...server } = await startTServer();
+
+  Object.assign(global, {
+    WebSocket: null,
+  });
+
+  createClient({
+    url: () => {return new Promise((resolve) => {resolve(url)})},
+    retryAttempts: 0,
+    onNonLazyError: noop,
+    lazy: false,
+    webSocketImpl: WebSocket,
+  });
+
+  await server.waitForClient();
+});
+
 it('should not accept invalid WebSocket implementations', async () => {
   const { url } = await startTServer();
 

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -148,7 +148,11 @@ it('should use the provided WebSocket implementation with url as a function that
   });
 
   createClient({
-    url: () => {return new Promise((resolve) => {resolve(url)})},
+    url: () => {
+      return new Promise((resolve) => {
+        resolve(url);
+      });
+    },
     retryAttempts: 0,
     onNonLazyError: noop,
     lazy: false,

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -140,23 +140,14 @@ it('should use the provided WebSocket implementation', async () => {
   await server.waitForClient();
 });
 
-it('should use the provided WebSocket implementation with url as a function that returns a Promise', async () => {
+it('should accept a function for the url', async () => {
   const { url, ...server } = await startTServer();
 
-  Object.assign(global, {
-    WebSocket: null,
-  });
-
   createClient({
-    url: () => {
-      return new Promise((resolve) => {
-        resolve(url);
-      });
-    },
+    url: () => Promise.resolve(url),
     retryAttempts: 0,
     onNonLazyError: noop,
     lazy: false,
-    webSocketImpl: WebSocket,
   });
 
   await server.waitForClient();


### PR DESCRIPTION
Closes #145, closes #146 

Updated `url` in `ClientOptions` to support function type that returns a Promise, the same way as `connectionParams`. The use case is that it can be used together with automatic reconnect on abnormal socket closure such that the url can be dynamically changing each time it reconnects.

Our specific use case: we have a service that checks the csrf token as part of the query string, so we have to add the csrf token to the `url`. The token might expire, and in that case, we would like to take advantage of the automatic reconnect functionality to be able to dynamically pick up an updated csrf token, and this can be achieved with a function that returns a Promise.

Specifically, we'd like to use it as:
`createClient({
  url: () => new Promise((resolve) => { resolve(getUrlWithLatestCsrfToken()) }),
  lazy: true,
})`