### PR TITLE
feat(server): Dynamic `schema` support by accepting a function or a Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,41 @@ useServer(
 
 </details>
 
+<details id="dynamic-schema">
+<summary><a href="#dynamic-schema">🔗</a> <a href="https://github.com/websockets/ws">ws</a> server usage with dynamic schema</summary>
+
+```typescript
+import { execute, subscribe } from 'graphql';
+import ws from 'ws'; // yarn add ws
+import { useServer } from 'graphql-ws/lib/use/ws';
+import { schema, checkIsAdmin, getDebugSchema } from './my-graphql';
+
+const wsServer = new ws.Server({
+  port: 443,
+  path: '/graphql',
+});
+
+useServer(
+  {
+    execute,
+    subscribe,
+    schema: async (ctx, msg, executionArgsWithoutSchema) => {
+      // will be called on every subscribe request
+      // allowing you to dynamically supply the schema
+      // using the depending on the provided arguments.
+      // throwing an error here closes the socket with
+      // the `Error` message in the close event reason
+      const isAdmin = await checkIsAdmin(ctx.request);
+      if (isAdmin) return getDebugSchema(ctx, msg, executionArgsWithoutSchema);
+      return schema;
+    },
+  },
+  wsServer,
+);
+```
+
+</details>
+
 <details id="custom-exec">
 <summary><a href="#custom-exec">🔗</a> <a href="https://github.com/websockets/ws">ws</a> server usage with custom execution arguments and validation</summary>
 

--- a/docs/interfaces/server.serveroptions.md
+++ b/docs/interfaces/server.serveroptions.md
@@ -410,14 +410,22 @@ ___
 
 ### schema
 
-• `Optional` **schema**: *GraphQLSchema*
+• `Optional` **schema**: *GraphQLSchema* \| (`ctx`: [*Context*](server.context.md)<E\>, `message`: [*SubscribeMessage*](message.subscribemessage.md), `args`: *Omit*<ExecutionArgs, *schema*\>) => *GraphQLSchema* \| *Promise*<GraphQLSchema\>
 
 The GraphQL schema on which the operations
 will be executed and validated against.
 
+If a function is provided, it will be called on
+every subscription request allowing you to manipulate
+schema dynamically.
+
 If the schema is left undefined, you're trusted to
 provide one in the returned `ExecutionArgs` from the
 `onSubscribe` callback.
+
+Throwing an error from within this function will
+close the socket with the `Error` message
+in the close event reason.
 
 ___
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,9 +57,17 @@ export interface ServerOptions<E = unknown> {
    * The GraphQL schema on which the operations
    * will be executed and validated against.
    *
+   * If a function is provided, it will be called on
+   * every subscription request allowing you to manipulate
+   * schema dynamically.
+   *
    * If the schema is left undefined, you're trusted to
    * provide one in the returned `ExecutionArgs` from the
    * `onSubscribe` callback.
+   *
+   * Throwing an error from within this function will
+   * close the socket with the `Error` message
+   * in the close event reason.
    */
   schema?:
     | GraphQLSchema

--- a/src/tests/fixtures/simple.ts
+++ b/src/tests/fixtures/simple.ts
@@ -5,6 +5,7 @@ import {
   execute,
   subscribe,
   GraphQLNonNull,
+  GraphQLSchemaConfig,
 } from 'graphql';
 import { EventEmitter } from 'events';
 import WebSocket from 'ws';
@@ -57,7 +58,7 @@ function pong(key = 'global'): void {
   }
 }
 
-export const schema = new GraphQLSchema({
+export const schemaConfig: GraphQLSchemaConfig = {
   query: new GraphQLObjectType({
     name: 'Query',
     fields: {
@@ -116,7 +117,9 @@ export const schema = new GraphQLSchema({
       },
     },
   }),
-});
+};
+
+export const schema = new GraphQLSchema(schemaConfig);
 
 export async function startTServer(
   options: Partial<ServerOptions<Extra>> = {},


### PR DESCRIPTION
Closes #127

Accept a function for the `schema` option that will be called on every subscription request allowing you to manipulate the schema dynamically.

Throwing an error from within this function will close the socket with the `Error` message in the close event reason.