### PR TITLE
perf(client): Focus subscription message listeners on `id`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -315,7 +315,7 @@ export function createClient(options: ClientOptions): Client {
     const listeners: { [event in Event]: EventListener<event>[] } = {
       connecting: on?.connecting ? [on.connecting] : [],
       connected: on?.connected ? [on.connected] : [],
-      message: on?.message ? [on.message, message.emit] : [message.emit],
+      message: on?.message ? [message.emit, on.message] : [message.emit],
       closed: on?.closed ? [on.closed] : [],
       error: on?.error ? [on.error] : [],
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -308,7 +308,8 @@ export function createClient(options: ClientOptions): Client {
             if (listener) {
               listener(message);
             }
-        },
+          }
+        }
       };
     })();
     const listeners: { [event in Event]: EventListener<event>[] } = {

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
   stringifyMessage,
   SubscribePayload,
 } from './message';
-import { isObject } from './utils';
+import { hasOwnStringProperty, isObject } from './utils';
 
 // this file is the entry point for browsers, re-export relevant elements
 export * from './message';
@@ -303,10 +303,10 @@ export function createClient(options: ClientOptions): Client {
           };
         },
         emit(message: Message) {
-          if (message.hasOwnProperty('id')) {
-            const id = (message as any).id;
-            if (listeners[id]) {
-              listeners[id](message);
+          if (isObject(message) && hasOwnStringProperty(message, 'id')) {
+            const listener = listeners[message.id];
+            if (listener) {
+              listener(message);
             }
           }
         },

--- a/src/client.ts
+++ b/src/client.ts
@@ -293,15 +293,35 @@ export function createClient(options: ClientOptions): Client {
 
   // websocket status emitter, subscriptions are handled differently
   const emitter = (() => {
+    const message = (() => {
+      const listeners: { [key: string]: EventMessageListener } = {};
+      return {
+        on(id: string, listener: EventMessageListener) {
+          listeners[id] = listener;
+          return () => {
+            delete listeners[id];
+          };
+        },
+        emit(message: Message) {
+          if (message.hasOwnProperty('id')) {
+            const id = (message as any).id;
+            if (listeners[id]) {
+              listeners[id](message);
+            }
+          }
+        },
+      };
+    })();
     const listeners: { [event in Event]: EventListener<event>[] } = {
       connecting: on?.connecting ? [on.connecting] : [],
       connected: on?.connected ? [on.connected] : [],
-      message: on?.message ? [on.message] : [],
+      message: on?.message ? [on.message, message.emit] : [message.emit],
       closed: on?.closed ? [on.closed] : [],
       error: on?.error ? [on.error] : [],
     };
 
     return {
+      onMessage: message.on,
       on<E extends Event>(event: E, listener: EventListener<E>) {
         const l = listeners[event] as EventListener<E>[];
         l.push(listener);
@@ -518,29 +538,25 @@ export function createClient(options: ClientOptions): Client {
             // if completed while waiting for connect, release the connection lock right away
             if (completed) return release();
 
-            const unlisten = emitter.on('message', (message) => {
+            const unlisten = emitter.onMessage(id, (message) => {
               switch (message.type) {
                 case MessageType.Next: {
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  if (message.id === id) sink.next(message.payload as any);
-                  return;
+                  sink.next(message.payload as any);
+                  break;
                 }
                 case MessageType.Error: {
-                  if (message.id === id) {
-                    completed = true;
-                    sink.error(message.payload);
-                    releaser();
-                    // TODO-db-201025 calling releaser will complete the sink, meaning that both the `error` and `complete` will be
-                    // called. neither promises or observables care; once they settle, additional calls to the resolvers will be ignored
-                  }
-                  return;
+                  completed = true;
+                  sink.error(message.payload);
+                  releaser();
+                  // TODO-db-201025 calling releaser will complete the sink, meaning that both the `error` and `complete` will be
+                  // called. neither promises or observables care; once they settle, additional calls to the resolvers will be ignored
+                  break;
                 }
                 case MessageType.Complete: {
-                  if (message.id === id) {
-                    completed = true;
-                    releaser(); // release completes the sink
-                  }
-                  return;
+                  completed = true;
+                  releaser(); // release completes the sink
+                  break;
                 }
               }
             });

--- a/src/client.ts
+++ b/src/client.ts
@@ -576,7 +576,7 @@ export function createClient(options: ClientOptions): Client {
           }
         }
       })()
-        .catch(sink.error)
+        .catch(sink.error) // rejects on close events and errors
         .then(sink.complete); // resolves on release or normal closure
 
       return () => releaser();

--- a/src/client.ts
+++ b/src/client.ts
@@ -543,7 +543,7 @@ export function createClient(options: ClientOptions): Client {
                 case MessageType.Next: {
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
                   sink.next(message.payload as any);
-                  break;
+                  return;
                 }
                 case MessageType.Error: {
                   completed = true;
@@ -551,12 +551,12 @@ export function createClient(options: ClientOptions): Client {
                   releaser();
                   // TODO-db-201025 calling releaser will complete the sink, meaning that both the `error` and `complete` will be
                   // called. neither promises or observables care; once they settle, additional calls to the resolvers will be ignored
-                  break;
+                  return;
                 }
                 case MessageType.Complete: {
                   completed = true;
                   releaser(); // release completes the sink
-                  break;
+                  return;
                 }
               }
             });

--- a/src/client.ts
+++ b/src/client.ts
@@ -304,10 +304,7 @@ export function createClient(options: ClientOptions): Client {
         },
         emit(message: Message) {
           if (isObject(message) && hasOwnStringProperty(message, 'id')) {
-            const listener = listeners[message.id];
-            if (listener) {
-              listener(message);
-            }
+            listeners[message.id]?.(message);
           }
         },
       };

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
   stringifyMessage,
   SubscribePayload,
 } from './message';
-import { hasOwnStringProperty, isObject } from './utils';
+import { isObject } from './utils';
 
 // this file is the entry point for browsers, re-export relevant elements
 export * from './message';
@@ -303,9 +303,7 @@ export function createClient(options: ClientOptions): Client {
           };
         },
         emit(message: Message) {
-          if (isObject(message) && hasOwnStringProperty(message, 'id')) {
-            listeners[message.id]?.(message);
-          }
+          if ('id' in message) listeners[message.id]?.(message);
         },
       };
     })();

--- a/src/client.ts
+++ b/src/client.ts
@@ -309,7 +309,7 @@ export function createClient(options: ClientOptions): Client {
               listener(message);
             }
           }
-        }
+        },
       };
     })();
     const listeners: { [event in Event]: EventListener<event>[] } = {


### PR DESCRIPTION
If client is used for a lot of simultaneous subscription, ther's unnecessary overload due to check MessageType and id for every subscription handler