### PR TITLE
feat: Support custom JSON message `reviver` and `replacer`

### DIFF
--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -13,6 +13,8 @@ Configuration used for the GraphQL over WebSocket client.
 - [connectionParams](client.clientoptions.md#connectionparams)
 - [generateID](client.clientoptions.md#generateid)
 - [isFatalConnectionProblem](client.clientoptions.md#isfatalconnectionproblem)
+- [jsonMessageReplacer](client.clientoptions.md#jsonmessagereplacer)
+- [jsonMessageReviver](client.clientoptions.md#jsonmessagereviver)
 - [keepAlive](client.clientoptions.md#keepalive)
 - [lazy](client.clientoptions.md#lazy)
 - [on](client.clientoptions.md#on)
@@ -89,6 +91,26 @@ option.
 | `errOrCloseEvent` | *unknown* |
 
 **Returns:** *boolean*
+
+___
+
+### jsonMessageReplacer
+
+• `Optional` **jsonMessageReplacer**: [*JSONMessageReplacer*](../modules/common.md#jsonmessagereplacer)
+
+An optional override for the JSON.stringify function used to serialize
+outgoing messages from this client. Useful for serializing custom
+datatypes out to the client.
+
+___
+
+### jsonMessageReviver
+
+• `Optional` **jsonMessageReviver**: [*JSONMessageReviver*](../modules/common.md#jsonmessagereviver)
+
+An optional override for the JSON.parse function used to hydrate
+incoming messages to this client. Useful for parsing custom datatypes
+out of the incoming JSON.
 
 ___
 

--- a/docs/interfaces/server.serveroptions.md
+++ b/docs/interfaces/server.serveroptions.md
@@ -17,6 +17,8 @@
 - [connectionInitWaitTimeout](server.serveroptions.md#connectioninitwaittimeout)
 - [context](server.serveroptions.md#context)
 - [execute](server.serveroptions.md#execute)
+- [jsonMessageReplacer](server.serveroptions.md#jsonmessagereplacer)
+- [jsonMessageReviver](server.serveroptions.md#jsonmessagereviver)
 - [onClose](server.serveroptions.md#onclose)
 - [onComplete](server.serveroptions.md#oncomplete)
 - [onConnect](server.serveroptions.md#onconnect)
@@ -91,6 +93,26 @@ in the close event reason.
 | `args` | ExecutionArgs |
 
 **Returns:** [*OperationResult*](../modules/server.md#operationresult)
+
+___
+
+### jsonMessageReplacer
+
+• `Optional` **jsonMessageReplacer**: [*JSONMessageReplacer*](../modules/common.md#jsonmessagereplacer)
+
+An optional override for the JSON.stringify function used to serialize
+outgoing messages to from server. Useful for serializing custom
+datatypes out to the client.
+
+___
+
+### jsonMessageReviver
+
+• `Optional` **jsonMessageReviver**: [*JSONMessageReviver*](../modules/common.md#jsonmessagereviver)
+
+An optional override for the JSON.parse function used to hydrate
+incoming messages to this server. Useful for parsing custom datatypes
+out of the incoming JSON.
 
 ___
 

--- a/docs/modules/client.md
+++ b/docs/modules/client.md
@@ -13,6 +13,8 @@
 - [ErrorMessage](client.md#errormessage)
 - [GRAPHQL\_TRANSPORT\_WS\_PROTOCOL](client.md#graphql_transport_ws_protocol)
 - [ID](client.md#id)
+- [JSONMessageReplacer](client.md#jsonmessagereplacer)
+- [JSONMessageReviver](client.md#jsonmessagereviver)
 - [Message](client.md#message)
 - [MessageType](client.md#messagetype)
 - [NextMessage](client.md#nextmessage)
@@ -256,6 +258,18 @@ ___
 ### ID
 
 Re-exports: [ID](common.md#id)
+
+___
+
+### JSONMessageReplacer
+
+Re-exports: [JSONMessageReplacer](common.md#jsonmessagereplacer)
+
+___
+
+### JSONMessageReviver
+
+Re-exports: [JSONMessageReviver](common.md#jsonmessagereviver)
 
 ___
 

--- a/docs/modules/common.md
+++ b/docs/modules/common.md
@@ -23,6 +23,8 @@
 ### Type aliases
 
 - [ID](common.md#id)
+- [JSONMessageReplacer](common.md#jsonmessagereplacer)
+- [JSONMessageReviver](common.md#jsonmessagereviver)
 - [Message](common.md#message)
 
 ### Variables
@@ -44,6 +46,58 @@
 ID is a string type alias representing
 the globally unique ID used for identifying
 subscriptions established by the client.
+
+___
+
+### JSONMessageReplacer
+
+Ƭ **JSONMessageReplacer**: (`this`: *any*, `key`: *string*, `value`: *any*) => *any*
+
+Function that allows customization of the produced JSON string
+for the elements of an outgoing `Message` object.
+
+Read more about using it:
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
+
+#### Type declaration:
+
+▸ (`this`: *any*, `key`: *string*, `value`: *any*): *any*
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `this` | *any* |
+| `key` | *string* |
+| `value` | *any* |
+
+**Returns:** *any*
+
+___
+
+### JSONMessageReviver
+
+Ƭ **JSONMessageReviver**: (`this`: *any*, `key`: *string*, `value`: *any*) => *any*
+
+Function for transforming values within a message during JSON parsing
+The values are produced by parsing the incoming raw JSON.
+
+Read more about using it:
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#using_the_reviver_parameter
+
+#### Type declaration:
+
+▸ (`this`: *any*, `key`: *string*, `value`: *any*): *any*
+
+#### Parameters:
+
+| Name | Type |
+| :------ | :------ |
+| `this` | *any* |
+| `key` | *string* |
+| `value` | *any* |
+
+**Returns:** *any*
 
 ___
 
@@ -85,7 +139,7 @@ ___
 
 ### parseMessage
 
-▸ **parseMessage**(`data`: *unknown*): [*Message*](common.md#message)
+▸ **parseMessage**(`data`: *unknown*, `reviver?`: [*JSONMessageReviver*](common.md#jsonmessagereviver)): [*Message*](common.md#message)
 
 Parses the raw websocket message data to a valid message.
 
@@ -94,6 +148,7 @@ Parses the raw websocket message data to a valid message.
 | Name | Type |
 | :------ | :------ |
 | `data` | *unknown* |
+| `reviver?` | [*JSONMessageReviver*](common.md#jsonmessagereviver) |
 
 **Returns:** [*Message*](common.md#message)
 
@@ -101,7 +156,7 @@ ___
 
 ### stringifyMessage
 
-▸ **stringifyMessage**<T\>(`msg`: [*Message*](common.md#message)<T\>): *string*
+▸ **stringifyMessage**<T\>(`msg`: [*Message*](common.md#message)<T\>, `replacer?`: [*JSONMessageReplacer*](common.md#jsonmessagereplacer)): *string*
 
 Stringifies a valid message ready to be sent through the socket.
 
@@ -116,5 +171,6 @@ Stringifies a valid message ready to be sent through the socket.
 | Name | Type |
 | :------ | :------ |
 | `msg` | [*Message*](common.md#message)<T\> |
+| `replacer?` | [*JSONMessageReplacer*](common.md#jsonmessagereplacer) |
 
 **Returns:** *string*

--- a/src/common.ts
+++ b/src/common.ts
@@ -191,23 +191,48 @@ export function isMessage(val: unknown): val is Message {
 }
 
 /**
+ * Function for transforming values within a message during JSON parsing
+ * The values are produced by parsing the incoming raw JSON.
+ *
+ * Read more about using it:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#using_the_reviver_parameter
+ *
+ * @category Common
+ */
+export type JSONMessageReviver = (this: any, key: string, value: any) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+/**
  * Parses the raw websocket message data to a valid message.
  *
  * @category Common
  */
-export function parseMessage(data: unknown): Message {
+export function parseMessage(
+  data: unknown,
+  reviver?: JSONMessageReviver,
+): Message {
   if (isMessage(data)) {
     return data;
   }
   if (typeof data !== 'string') {
     throw new Error('Message not parsable');
   }
-  const message = JSON.parse(data);
+  const message = JSON.parse(data, reviver);
   if (!isMessage(message)) {
     throw new Error('Invalid message');
   }
   return message;
 }
+
+/**
+ * Function that allows customization of the produced JSON string
+ * for the elements of an outgoing `Message` object.
+ *
+ * Read more about using it:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter
+ *
+ * @category Common
+ */
+export type JSONMessageReplacer = (this: any, key: string, value: any) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 /**
  * Stringifies a valid message ready to be sent through the socket.
@@ -216,9 +241,10 @@ export function parseMessage(data: unknown): Message {
  */
 export function stringifyMessage<T extends MessageType>(
   msg: Message<T>,
+  replacer?: JSONMessageReplacer,
 ): string {
   if (!isMessage(msg)) {
     throw new Error('Cannot stringify invalid message');
   }
-  return JSON.stringify(msg);
+  return JSON.stringify(msg, replacer);
 }

--- a/src/tests/fixtures/simple.ts
+++ b/src/tests/fixtures/simple.ts
@@ -26,10 +26,6 @@ export const schemaConfig: GraphQLSchemaConfig = {
         type: new GraphQLNonNull(GraphQLString),
         resolve: () => 'value',
       },
-      value: {
-        type: new GraphQLNonNull(GraphQLString),
-        resolve: () => 'value',
-      },
     },
   }),
   subscription: new GraphQLObjectType({

--- a/src/tests/fixtures/simple.ts
+++ b/src/tests/fixtures/simple.ts
@@ -26,6 +26,10 @@ export const schemaConfig: GraphQLSchemaConfig = {
         type: new GraphQLNonNull(GraphQLString),
         resolve: () => 'value',
       },
+      value: {
+        type: new GraphQLNonNull(GraphQLString),
+        resolve: () => 'value',
+      },
     },
   }),
   subscription: new GraphQLObjectType({

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -416,6 +416,52 @@ it('should prefer the `onSubscribe` context value even if `context` option is se
   );
 });
 
+it('should use a custom JSON message replacer function', async () => {
+  const { url } = await startTServer({
+    schema,
+    jsonMessageReplacer: (key, value) => {
+      if (key === 'type') {
+        return 'CONNECTION_ACK';
+      }
+      return value;
+    },
+  });
+
+  const client = await createTClient(url);
+  client.ws.send(
+    stringifyMessage<MessageType.ConnectionInit>({
+      type: MessageType.ConnectionInit,
+    }),
+  );
+
+  await client.waitForMessage(({ data }) => {
+    expect(data).toBe('{"type":"CONNECTION_ACK"}');
+  });
+});
+
+it('should use a custom JSON message reviver function', async () => {
+  const { url } = await startTServer({
+    schema,
+    jsonMessageReviver: (key, value) => {
+      if (key === 'type') {
+        return MessageType.ConnectionInit;
+      }
+      return value;
+    },
+  });
+
+  const client = await createTClient(url);
+  client.ws.send(
+    JSON.stringify({
+      type: MessageType.ConnectionInit.toUpperCase(),
+    }),
+  );
+
+  await client.waitForMessage(({ data }) => {
+    expect(parseMessage(data).type).toBe(MessageType.ConnectionAck);
+  });
+});
+
 describe('Connect', () => {
   it('should refuse connection and close socket if returning `false`', async () => {
     const { url } = await startTServer({
@@ -1526,56 +1572,6 @@ describe('Subscribe', () => {
     }, 30);
 
     await server.waitForComplete();
-  });
-
-  it('should use a custom JSON message replacer function', async () => {
-    const { url } = await startTServer({
-      schema,
-      jsonMessageReplacer: (_, value) => {
-        if (typeof value == 'string') {
-          return value.toUpperCase();
-        }
-        return value;
-      },
-    });
-
-    const client = await createTClient(url);
-    client.ws.send(
-      stringifyMessage<MessageType.ConnectionInit>({
-        type: MessageType.ConnectionInit,
-      }),
-    );
-
-    await client.waitForMessage(({ data }) => {
-      expect(data).toBe('{"type":"CONNECTION_ACK"}');
-    });
-
-    client.ws.close(4321, 'Byebye');
-  });
-
-  it('should use a custom JSON message reviver function', async () => {
-    const { url } = await startTServer({
-      schema,
-      jsonMessageReviver: (_, value) => {
-        if (typeof value == 'string') {
-          return value.toLowerCase();
-        }
-        return value;
-      },
-    });
-
-    const client = await createTClient(url);
-    client.ws.send(
-      JSON.stringify({
-        type: MessageType.ConnectionInit.toUpperCase(),
-      }),
-    );
-
-    await client.waitForMessage(({ data }) => {
-      expect(parseMessage(data).type).toBe(MessageType.ConnectionAck);
-    });
-
-    client.ws.close(4321, 'Byebye');
   });
 });
 


### PR DESCRIPTION
If you want to use a fancier types inside your JSON over the websocket like bigints or dates, it's handy to be able to control the stringification and unstringifiation of the messages going across this socket! This adds options to the server to allow overriding the `revive` and `replace` functions the server uses in JSON.stringify and JSON.parse so userland can hook in and alter the behaviour. We stay compatible with the graphql-ws protocol by sticking with JSON but still allow flexibility to marshal fancier types to and from JSON easily.