### PR TITLE
feat(uWebSockets): Add `persistedRequest` to context extra and deprecate uWS's stack allocated `request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,57 +769,6 @@ wsServer.on('connection', (socket, request) => {
 
 </details>
 
-<details id="uws-auth-handling">
-<summary><a href="#uws-auth-handling">🔗</a> Server usage with <a href="https://github.com/uNetworking/uWebSockets.js">uWebSockets.js</a> and custom auth handling</summary>
-
-```typescript
-import uWS from 'uWebSockets.js'; // yarn add uWebSockets.js@uNetworking/uWebSockets.js#<tag>
-import cookie from 'cookie';
-import { makeBehavior, Request } from 'graphql-ws/lib/use/uWebSockets';
-import { schema } from './my-graphql-schema';
-import { validate } from './my-auth';
-
-// your custom auth
-class Forbidden extends Error {}
-function handleAuth(request: Request) {
-  // do your auth on every subscription connect
-  const good = validate(request.headers['authorization']);
-  // or const { iDontApprove } = session(cookie.parse(request.headers.cookie));
-  if (!good) {
-    // throw a custom error to be handled
-    throw new Forbidden(':(');
-  }
-}
-
-uWS
-  .App()
-  .ws(
-    '/graphql',
-    makeBehavior({
-      schema,
-      onConnect: async (ctx) => {
-        // do your auth on every connect
-        await handleAuth(ctx.extra.request);
-      },
-      onSubscribe: async (ctx) => {
-        // or maybe on every subscribe
-        await handleAuth(ctx.extra.request);
-      },
-      onNext: async (ctx) => {
-        // haha why not on every result emission?
-        await handleAuth(ctx.extra.request);
-      },
-    }),
-  )
-  .listen(4000, (listenSocket) => {
-    if (listenSocket) {
-      console.log('Listening to port 4000');
-    }
-  });
-```
-
-</details>
-
 <details id="express">
 <summary><a href="#express">🔗</a> <a href="https://github.com/websockets/ws">ws</a> server usage with <a href="https://github.com/graphql/express-graphql">Express GraphQL</a></summary>
 

--- a/README.md
+++ b/README.md
@@ -769,6 +769,57 @@ wsServer.on('connection', (socket, request) => {
 
 </details>
 
+<details id="uws-auth-handling">
+<summary><a href="#uws-auth-handling">🔗</a> Server usage with <a href="https://github.com/uNetworking/uWebSockets.js">uWebSockets.js</a> and custom auth handling</summary>
+
+```typescript
+import uWS from 'uWebSockets.js'; // yarn add uWebSockets.js@uNetworking/uWebSockets.js#<tag>
+import cookie from 'cookie';
+import { makeBehavior, Request } from 'graphql-ws/lib/use/uWebSockets';
+import { schema } from './my-graphql-schema';
+import { validate } from './my-auth';
+
+// your custom auth
+class Forbidden extends Error {}
+function handleAuth(request: Request) {
+  // do your auth on every subscription connect
+  const good = validate(request.headers['authorization']);
+  // or const { iDontApprove } = session(cookie.parse(request.headers.cookie));
+  if (!good) {
+    // throw a custom error to be handled
+    throw new Forbidden(':(');
+  }
+}
+
+uWS
+  .App()
+  .ws(
+    '/graphql',
+    makeBehavior({
+      schema,
+      onConnect: async (ctx) => {
+        // do your auth on every connect
+        await handleAuth(ctx.extra.request);
+      },
+      onSubscribe: async (ctx) => {
+        // or maybe on every subscribe
+        await handleAuth(ctx.extra.request);
+      },
+      onNext: async (ctx) => {
+        // haha why not on every result emission?
+        await handleAuth(ctx.extra.request);
+      },
+    }),
+  )
+  .listen(4000, (listenSocket) => {
+    if (listenSocket) {
+      console.log('Listening to port 4000');
+    }
+  });
+```
+
+</details>
+
 <details id="express">
 <summary><a href="#express">🔗</a> <a href="https://github.com/websockets/ws">ws</a> server usage with <a href="https://github.com/graphql/express-graphql">Express GraphQL</a></summary>
 

--- a/docs/interfaces/use_uwebsockets.extra.md
+++ b/docs/interfaces/use_uwebsockets.extra.md
@@ -26,6 +26,14 @@ The extra that will be put in the `Context`.
 
 • `Readonly` **persistedRequest**: [*PersistedRequest*](use_uwebsockets.persistedrequest.md)
 
+The initial HTTP upgrade request before the actual
+socket and connection is established.
+
+uWS's request is stack allocated and cannot be accessed
+from outside of the internal upgrade; therefore, the persisted
+request holds the relevant values extracted from the uWS's request
+while it is accessible.
+
 Inherited from: [UpgradeData](use_uwebsockets.upgradedata.md).[persistedRequest](use_uwebsockets.upgradedata.md#persistedrequest)
 
 ___

--- a/docs/interfaces/use_uwebsockets.extra.md
+++ b/docs/interfaces/use_uwebsockets.extra.md
@@ -6,14 +6,29 @@
 
 The extra that will be put in the `Context`.
 
+## Hierarchy
+
+- [*UpgradeData*](use_uwebsockets.upgradedata.md)
+
+  ↳ **Extra**
+
 ## Table of contents
 
 ### Properties
 
+- [persistedRequest](use_uwebsockets.extra.md#persistedrequest)
 - [request](use_uwebsockets.extra.md#request)
 - [socket](use_uwebsockets.extra.md#socket)
 
 ## Properties
+
+### persistedRequest
+
+• `Readonly` **persistedRequest**: [*PersistedRequest*](use_uwebsockets.persistedrequest.md)
+
+Inherited from: [UpgradeData](use_uwebsockets.upgradedata.md).[persistedRequest](use_uwebsockets.upgradedata.md#persistedrequest)
+
+___
 
 ### request
 
@@ -22,10 +37,15 @@ The extra that will be put in the `Context`.
 The initial HTTP request before the actual
 socket and connection is established.
 
+**`deprecated`** uWS.HttpRequest is stack allocated and cannot be accessed outside the internal `upgrade` callback. Consider using the `persistedRequest` instead.
+
+Inherited from: [UpgradeData](use_uwebsockets.upgradedata.md).[request](use_uwebsockets.upgradedata.md#request)
+
 ___
 
 ### socket
 
-• `Readonly` **socket**: WebSocket
+• `Readonly` **socket**: WebSocket & [*UpgradeData*](use_uwebsockets.upgradedata.md)
 
-The actual socket connection between the server and the client.
+The actual socket connection between the server and the client
+with the upgrade data.

--- a/docs/interfaces/use_uwebsockets.persistedrequest.md
+++ b/docs/interfaces/use_uwebsockets.persistedrequest.md
@@ -18,6 +18,7 @@ while it is accessible.
 
 - [headers](use_uwebsockets.persistedrequest.md#headers)
 - [method](use_uwebsockets.persistedrequest.md#method)
+- [query](use_uwebsockets.persistedrequest.md#query)
 - [url](use_uwebsockets.persistedrequest.md#url)
 
 ## Properties
@@ -31,6 +32,14 @@ ___
 ### method
 
 • **method**: *string*
+
+___
+
+### query
+
+• **query**: *string*
+
+The raw query string (after the `?` sign) or empty string.
 
 ___
 

--- a/docs/interfaces/use_uwebsockets.persistedrequest.md
+++ b/docs/interfaces/use_uwebsockets.persistedrequest.md
@@ -1,0 +1,39 @@
+[graphql-ws](../README.md) / [use/uWebSockets](../modules/use_uwebsockets.md) / PersistedRequest
+
+# Interface: PersistedRequest
+
+[use/uWebSockets](../modules/use_uwebsockets.md).PersistedRequest
+
+The initial HTTP upgrade request before the actual
+socket and connection is established.
+
+uWS's request is stack allocated and cannot be accessed
+from outside of the internal upgrade; therefore, the persisted
+request holds relevant values extracted from the uWS's request
+while it is accessible.
+
+## Table of contents
+
+### Properties
+
+- [headers](use_uwebsockets.persistedrequest.md#headers)
+- [method](use_uwebsockets.persistedrequest.md#method)
+- [url](use_uwebsockets.persistedrequest.md#url)
+
+## Properties
+
+### headers
+
+• **headers**: *IncomingHttpHeaders*
+
+___
+
+### method
+
+• **method**: *string*
+
+___
+
+### url
+
+• **url**: *string*

--- a/docs/interfaces/use_uwebsockets.upgradedata.md
+++ b/docs/interfaces/use_uwebsockets.upgradedata.md
@@ -25,6 +25,14 @@ Data acquired during the HTTP upgrade callback from uWS.
 
 • `Readonly` **persistedRequest**: [*PersistedRequest*](use_uwebsockets.persistedrequest.md)
 
+The initial HTTP upgrade request before the actual
+socket and connection is established.
+
+uWS's request is stack allocated and cannot be accessed
+from outside of the internal upgrade; therefore, the persisted
+request holds the relevant values extracted from the uWS's request
+while it is accessible.
+
 ___
 
 ### request

--- a/docs/interfaces/use_uwebsockets.upgradedata.md
+++ b/docs/interfaces/use_uwebsockets.upgradedata.md
@@ -1,0 +1,37 @@
+[graphql-ws](../README.md) / [use/uWebSockets](../modules/use_uwebsockets.md) / UpgradeData
+
+# Interface: UpgradeData
+
+[use/uWebSockets](../modules/use_uwebsockets.md).UpgradeData
+
+Data acquired during the HTTP upgrade callback from uWS.
+
+## Hierarchy
+
+- **UpgradeData**
+
+  ↳ [*Extra*](use_uwebsockets.extra.md)
+
+## Table of contents
+
+### Properties
+
+- [persistedRequest](use_uwebsockets.upgradedata.md#persistedrequest)
+- [request](use_uwebsockets.upgradedata.md#request)
+
+## Properties
+
+### persistedRequest
+
+• `Readonly` **persistedRequest**: [*PersistedRequest*](use_uwebsockets.persistedrequest.md)
+
+___
+
+### request
+
+• `Readonly` **request**: HttpRequest
+
+The initial HTTP request before the actual
+socket and connection is established.
+
+**`deprecated`** uWS.HttpRequest is stack allocated and cannot be accessed outside the internal `upgrade` callback. Consider using the `persistedRequest` instead.

--- a/docs/modules/use_uwebsockets.md
+++ b/docs/modules/use_uwebsockets.md
@@ -7,6 +7,8 @@
 ### Interfaces
 
 - [Extra](../interfaces/use_uwebsockets.extra.md)
+- [PersistedRequest](../interfaces/use_uwebsockets.persistedrequest.md)
+- [UpgradeData](../interfaces/use_uwebsockets.upgradedata.md)
 
 ### Functions
 

--- a/src/tests/use.ts
+++ b/src/tests/use.ts
@@ -88,10 +88,21 @@ for (const { tServer, startTServer } of tServers) {
               expect((ctx.extra as UWSExtra).socket.constructor.name).toEqual(
                 'uWS.WebSocket',
               );
-              expect((ctx.extra as UWSExtra).request).toBeInstanceOf(Object);
-              expect((ctx.extra as UWSExtra).request.headers).toBeInstanceOf(
-                Object,
+              expect((ctx.extra as UWSExtra).request.constructor.name).toEqual(
+                'uWS.HttpRequest',
               );
+              expect((ctx.extra as UWSExtra).persistedRequest.method).toBe(
+                'get',
+              );
+              expect((ctx.extra as UWSExtra).persistedRequest.url).toBe(
+                '/simple',
+              );
+              expect((ctx.extra as UWSExtra).persistedRequest.query).toBe(
+                'te=st',
+              );
+              expect(
+                (ctx.extra as UWSExtra).persistedRequest.headers,
+              ).toBeInstanceOf(Object);
             } else if (tServer === 'ws') {
               expect((ctx.extra as WSExtra).socket).toBeInstanceOf(ws);
               expect((ctx.extra as WSExtra).request).toBeInstanceOf(
@@ -105,7 +116,7 @@ for (const { tServer, startTServer } of tServers) {
           },
         });
 
-        const client = await createTClient(server.url);
+        const client = await createTClient(server.url + '?te=st');
         client.ws.send(
           stringifyMessage<MessageType.ConnectionInit>({
             type: MessageType.ConnectionInit,

--- a/src/tests/use.ts
+++ b/src/tests/use.ts
@@ -88,8 +88,9 @@ for (const { tServer, startTServer } of tServers) {
               expect((ctx.extra as UWSExtra).socket.constructor.name).toEqual(
                 'uWS.WebSocket',
               );
-              expect((ctx.extra as UWSExtra).request.constructor.name).toEqual(
-                'uWS.HttpRequest',
+              expect((ctx.extra as UWSExtra).request).toBeInstanceOf(Object);
+              expect((ctx.extra as UWSExtra).request.headers).toBeInstanceOf(
+                Object,
               );
             } else if (tServer === 'ws') {
               expect((ctx.extra as WSExtra).socket).toBeInstanceOf(ws);


### PR DESCRIPTION
Due to [this limitation](https://github.com/uNetworking/uWebSockets.js/discussions/84) (for performance optimizations), we can't use [uWS.HttpRequest ](https://unetworking.github.io/uWebSockets.js/generated/interfaces/httprequest.html) out of  scope of `upgrade` callback, and it wasn't possible to get some headers from `upgradeReq`.