### PR TITLE
feat: Bidirectional ping/pong message types

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -60,7 +60,11 @@ The client is now **ready** to request subscription operations.
 
 Direction: **bidirectional**
 
-Ping the other party. Useful for detecting failed connections, displaying latency metrics or other types of network probing.
+Useful for detecting failed connections, displaying latency metrics or other types of network probing.
+
+A `Pong` must be sent in response by the receiving party.
+
+The `Ping` message can be sent at any time within the established socket.
 
 ```typescript
 interface PingMessage {
@@ -72,7 +76,9 @@ interface PingMessage {
 
 Direction: **bidirectional**
 
-The response message to the `Ping`. Must be sent as soon as the `Ping` message is received.
+The response to the `Ping` message. Must be sent as soon as the `Ping` message is received.
+
+The `Pong` message can be sent at any time within the established socket. Meaning, the `Pong` message may be sent unsolicited as an unidirectional heartbeat.
 
 ```typescript
 interface PongMessage {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -60,9 +60,9 @@ The client is now **ready** to request subscription operations.
 
 Direction: **bidirectional**
 
-Ping the other party. This message can be issued at any point after the connection is acknowledged.
+Ping the other party. Useful for detecting failed connections, displaying latency metrics or other types of network probing.
 
-_<define what happens if pinging within an unacknowledged connection>_
+_<decide if only server is affected>_ This message can be issued at any point after the connection is acknowledged. If the connection is not acknowledged, and a ping is sent, the socket will be closed immediately with the event `4401: Unauthorized`.
 
 ```typescript
 interface PingMessage {
@@ -75,6 +75,8 @@ interface PingMessage {
 Direction: **bidirectional**
 
 The response message to the `Ping`. Must be sent as soon as the `Ping` message is received.
+
+_<decide if only server is affected>_ This message can be issued at any point after the connection is acknowledged. If the connection is not acknowledged, and a pong is sent, the socket will be closed immediately with the event `4401: Unauthorized`.
 
 ```typescript
 interface PongMessage {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -62,7 +62,7 @@ Direction: **bidirectional**
 
 Useful for detecting failed connections, displaying latency metrics or other types of network probing.
 
-A `Pong` must be sent in response by the receiving party.
+A `Pong` must be sent in response from the receiving party as soon as possible.
 
 The `Ping` message can be sent at any time within the established socket.
 
@@ -78,7 +78,7 @@ Direction: **bidirectional**
 
 The response to the `Ping` message. Must be sent as soon as the `Ping` message is received.
 
-The `Pong` message can be sent at any time within the established socket. Meaning, the `Pong` message may be sent unsolicited as an unidirectional heartbeat.
+The `Pong` message can be sent at any time within the established socket. Furthermore, the `Pong` message may even be sent unsolicited as an unidirectional heartbeat.
 
 ```typescript
 interface PongMessage {

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -56,6 +56,32 @@ interface ConnectionAckMessage {
 
 The client is now **ready** to request subscription operations.
 
+### `Ping`
+
+Direction: **bidirectional**
+
+Ping the other party. This message can be issued at any point after the connection is acknowledged.
+
+_<define what happens if pinging within an unacknowledged connection>_
+
+```typescript
+interface PingMessage {
+  type: 'ping';
+}
+```
+
+### `Pong`
+
+Direction: **bidirectional**
+
+The response message to the `Ping`. Must be sent as soon as the `Ping` message is received.
+
+```typescript
+interface PongMessage {
+  type: 'pong';
+}
+```
+
 ### `Subscribe`
 
 Direction: **Client -> Server**

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -62,8 +62,6 @@ Direction: **bidirectional**
 
 Ping the other party. Useful for detecting failed connections, displaying latency metrics or other types of network probing.
 
-_<decide if only server is affected>_ This message can be issued at any point after the connection is acknowledged. If the connection is not acknowledged, and a ping is sent, the socket will be closed immediately with the event `4401: Unauthorized`.
-
 ```typescript
 interface PingMessage {
   type: 'ping';
@@ -75,8 +73,6 @@ interface PingMessage {
 Direction: **bidirectional**
 
 The response message to the `Ping`. Must be sent as soon as the `Ping` message is received.
-
-_<decide if only server is affected>_ This message can be issued at any point after the connection is acknowledged. If the connection is not acknowledged, and a pong is sent, the socket will be closed immediately with the event `4401: Unauthorized`.
 
 ```typescript
 interface PongMessage {

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ let timedOut,
   latency = 0;
 createClient({
   url: 'ws://i.time.out:4000/and-measure/latency',
-  // TODO-db-210608 keep alive option
+  keepAlive: 10_000, // ping server every 10 seconds
   on: {
     ping: (socket, received) => {
       if (!received /* sent */) {
@@ -608,7 +608,7 @@ createClient({
         timedOut = setTimeout(() => {
           if (socket.readyState === WebSocket.OPEN)
             socket.close(4408, 'Request Timeout');
-        }, 10_000); // wait 10 seconds for the pong and then close the connection
+        }, 5_000); // wait 5 seconds for the pong and then close the connection
       }
     },
     pong: (_socket, received) => {

--- a/docs/enums/common.messagetype.md
+++ b/docs/enums/common.messagetype.md
@@ -15,6 +15,8 @@ Types of messages allowed to be sent by the client/server over the WS protocol.
 - [ConnectionInit](common.messagetype.md#connectioninit)
 - [Error](common.messagetype.md#error)
 - [Next](common.messagetype.md#next)
+- [Ping](common.messagetype.md#ping)
+- [Pong](common.messagetype.md#pong)
 - [Subscribe](common.messagetype.md#subscribe)
 
 ## Enumeration members
@@ -46,6 +48,18 @@ ___
 ### Next
 
 • **Next** = "next"
+
+___
+
+### Ping
+
+• **Ping** = "ping"
+
+___
+
+### Pong
+
+• **Pong** = "pong"
 
 ___
 

--- a/docs/interfaces/client.clientoptions.md
+++ b/docs/interfaces/client.clientoptions.md
@@ -15,6 +15,7 @@ Configuration used for the GraphQL over WebSocket client.
 - [isFatalConnectionProblem](client.clientoptions.md#isfatalconnectionproblem)
 - [jsonMessageReplacer](client.clientoptions.md#jsonmessagereplacer)
 - [jsonMessageReviver](client.clientoptions.md#jsonmessagereviver)
+- [keepAlive](client.clientoptions.md#keepalive)
 - [lazy](client.clientoptions.md#lazy)
 - [lazyCloseTimeout](client.clientoptions.md#lazyclosetimeout)
 - [on](client.clientoptions.md#on)
@@ -115,6 +116,47 @@ ___
 An optional override for the JSON.parse function used to hydrate
 incoming messages to this client. Useful for parsing custom datatypes
 out of the incoming JSON.
+
+___
+
+### keepAlive
+
+• `Optional` **keepAlive**: `number`
+
+The timout between dispatched keep-alive messages, naimly server pings. Internally
+dispatches the `PingMessage` type to the server and expects a `PongMessage` in response.
+This helps with making sure that the connection with the server is alive and working.
+
+Timeout countdown starts from the moment the socket was opened and subsequently
+after every received `PongMessage`.
+
+Note that NOTHING will happen automatically with the client if the server never
+responds to a `PingMessage` with a `PongMessage`. If you want the connection to close,
+you should implement your own logic on top of the client. A simple example looks like this:
+
+```js
+import { createClient } from 'graphql-ws';
+
+let timedOut;
+createClient({
+  url: 'ws://i.time.out:4000/after-5/seconds',
+  keepAlive: 10_000, // ping server every 10 seconds
+  on: {
+    ping: (socket, received) => {
+     if (!received) // sent
+       timedOut = setTimeout(() => {
+         if (socket.readyState === WebSocket.OPEN)
+           socket.close(4408, 'Request Timeout');
+       }, 5_000); // wait 5 seconds for the pong and then close the connection
+    },
+    pong: (_socket, received) => {
+      if (received) clearTimeout(timedOut); // pong is received, clear connection close timeout
+    },
+  },
+});
+```
+
+**`default`** 0
 
 ___
 

--- a/docs/interfaces/common.pingmessage.md
+++ b/docs/interfaces/common.pingmessage.md
@@ -1,0 +1,17 @@
+[graphql-ws](../README.md) / [common](../modules/common.md) / PingMessage
+
+# Interface: PingMessage
+
+[common](../modules/common.md).PingMessage
+
+## Table of contents
+
+### Properties
+
+- [type](common.pingmessage.md#type)
+
+## Properties
+
+### type
+
+• `Readonly` **type**: [Ping](../enums/common.messagetype.md#ping)

--- a/docs/interfaces/common.pongmessage.md
+++ b/docs/interfaces/common.pongmessage.md
@@ -1,0 +1,17 @@
+[graphql-ws](../README.md) / [common](../modules/common.md) / PongMessage
+
+# Interface: PongMessage
+
+[common](../modules/common.md).PongMessage
+
+## Table of contents
+
+### Properties
+
+- [type](common.pongmessage.md#type)
+
+## Properties
+
+### type
+
+• `Readonly` **type**: [Pong](../enums/common.messagetype.md#pong)

--- a/docs/modules/client.md
+++ b/docs/modules/client.md
@@ -233,8 +233,8 @@ The first argument is actually the `WebSocket`, but to avoid
 bundling DOM typings because the client can run in Node env too,
 you should assert the websocket type during implementation.
 
-Second argument indicates whether the ping was received from the server.
-If `false`, then the ping was sent by the client.
+Second argument communicates whether the ping was received from the server.
+If `false`, the ping was sent by the client.
 
 #### Type declaration
 
@@ -267,8 +267,8 @@ The first argument is actually the `WebSocket`, but to avoid
 bundling DOM typings because the client can run in Node env too,
 you should assert the websocket type during implementation.
 
-Second argument indicates whether the pong was received from the server.
-If `false`, then the pong was sent by the client.
+Second argument communicates whether the pong was received from the server.
+If `false`, the pong was sent by the client.
 
 #### Type declaration
 

--- a/docs/modules/client.md
+++ b/docs/modules/client.md
@@ -227,24 +227,19 @@ ___
 
 ### EventPingListener
 
-Ƭ **EventPingListener**: (`socket`: `unknown`, `received`: `boolean`) => `void`
+Ƭ **EventPingListener**: (`received`: `boolean`) => `void`
 
-The first argument is actually the `WebSocket`, but to avoid
-bundling DOM typings because the client can run in Node env too,
-you should assert the websocket type during implementation.
-
-Second argument communicates whether the ping was received from the server.
+The first argument communicates whether the ping was received from the server.
 If `false`, the ping was sent by the client.
 
 #### Type declaration
 
-▸ (`socket`, `received`): `void`
+▸ (`received`): `void`
 
 ##### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `socket` | `unknown` |
 | `received` | `boolean` |
 
 ##### Returns
@@ -261,24 +256,19 @@ ___
 
 ### EventPongListener
 
-Ƭ **EventPongListener**: (`socket`: `unknown`, `received`: `boolean`) => `void`
+Ƭ **EventPongListener**: (`received`: `boolean`) => `void`
 
-The first argument is actually the `WebSocket`, but to avoid
-bundling DOM typings because the client can run in Node env too,
-you should assert the websocket type during implementation.
-
-Second argument communicates whether the pong was received from the server.
+The first argument communicates whether the pong was received from the server.
 If `false`, the pong was sent by the client.
 
 #### Type declaration
 
-▸ (`socket`, `received`): `void`
+▸ (`received`): `void`
 
 ##### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `socket` | `unknown` |
 | `received` | `boolean` |
 
 ##### Returns

--- a/docs/modules/client.md
+++ b/docs/modules/client.md
@@ -18,6 +18,8 @@
 - [Message](client.md#message)
 - [MessageType](client.md#messagetype)
 - [NextMessage](client.md#nextmessage)
+- [PingMessage](client.md#pingmessage)
+- [PongMessage](client.md#pongmessage)
 - [Sink](client.md#sink)
 - [SubscribeMessage](client.md#subscribemessage)
 - [SubscribePayload](client.md#subscribepayload)
@@ -44,6 +46,10 @@
 - [EventListener](client.md#eventlistener)
 - [EventMessage](client.md#eventmessage)
 - [EventMessageListener](client.md#eventmessagelistener)
+- [EventPing](client.md#eventping)
+- [EventPingListener](client.md#eventpinglistener)
+- [EventPong](client.md#eventpong)
+- [EventPongListener](client.md#eventponglistener)
 
 ### Functions
 
@@ -53,7 +59,7 @@
 
 ### Event
 
-Ƭ **Event**: [EventConnecting](client.md#eventconnecting) \| [EventConnected](client.md#eventconnected) \| [EventMessage](client.md#eventmessage) \| [EventClosed](client.md#eventclosed) \| [EventError](client.md#eventerror)
+Ƭ **Event**: [EventConnecting](client.md#eventconnecting) \| [EventConnected](client.md#eventconnected) \| [EventPing](client.md#eventping) \| [EventPong](client.md#eventpong) \| [EventMessage](client.md#eventmessage) \| [EventClosed](client.md#eventclosed) \| [EventError](client.md#eventerror)
 
 ___
 
@@ -174,7 +180,7 @@ ___
 
 ### EventListener
 
-Ƭ **EventListener**<E\>: `E` extends [EventConnecting](client.md#eventconnecting) ? [EventConnectingListener](client.md#eventconnectinglistener) : `E` extends [EventConnected](client.md#eventconnected) ? [EventConnectedListener](client.md#eventconnectedlistener) : `E` extends [EventMessage](client.md#eventmessage) ? [EventMessageListener](client.md#eventmessagelistener) : `E` extends [EventClosed](client.md#eventclosed) ? [EventClosedListener](client.md#eventclosedlistener) : `E` extends [EventError](client.md#eventerror) ? [EventErrorListener](client.md#eventerrorlistener) : `never`
+Ƭ **EventListener**<E\>: `E` extends [EventConnecting](client.md#eventconnecting) ? [EventConnectingListener](client.md#eventconnectinglistener) : `E` extends [EventConnected](client.md#eventconnected) ? [EventConnectedListener](client.md#eventconnectedlistener) : `E` extends [EventPing](client.md#eventping) ? [EventPingListener](client.md#eventpinglistener) : `E` extends [EventPong](client.md#eventpong) ? [EventPongListener](client.md#eventponglistener) : `E` extends [EventMessage](client.md#eventmessage) ? [EventMessageListener](client.md#eventmessagelistener) : `E` extends [EventClosed](client.md#eventclosed) ? [EventClosedListener](client.md#eventclosedlistener) : `E` extends [EventError](client.md#eventerror) ? [EventErrorListener](client.md#eventerrorlistener) : `never`
 
 #### Type parameters
 
@@ -206,6 +212,74 @@ debugging and logging received messages.
 | Name | Type |
 | :------ | :------ |
 | `message` | [Message](common.md#message) |
+
+##### Returns
+
+`void`
+
+___
+
+### EventPing
+
+Ƭ **EventPing**: ``"ping"``
+
+___
+
+### EventPingListener
+
+Ƭ **EventPingListener**: (`socket`: `unknown`, `received`: `boolean`) => `void`
+
+The first argument is actually the `WebSocket`, but to avoid
+bundling DOM typings because the client can run in Node env too,
+you should assert the websocket type during implementation.
+
+Second argument indicates whether the ping was received from the server.
+If `false`, then the ping was sent by the client.
+
+#### Type declaration
+
+▸ (`socket`, `received`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `socket` | `unknown` |
+| `received` | `boolean` |
+
+##### Returns
+
+`void`
+
+___
+
+### EventPong
+
+Ƭ **EventPong**: ``"pong"``
+
+___
+
+### EventPongListener
+
+Ƭ **EventPongListener**: (`socket`: `unknown`, `received`: `boolean`) => `void`
+
+The first argument is actually the `WebSocket`, but to avoid
+bundling DOM typings because the client can run in Node env too,
+you should assert the websocket type during implementation.
+
+Second argument indicates whether the pong was received from the server.
+If `false`, then the pong was sent by the client.
+
+#### Type declaration
+
+▸ (`socket`, `received`): `void`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `socket` | `unknown` |
+| `received` | `boolean` |
 
 ##### Returns
 
@@ -300,6 +374,18 @@ ___
 ### NextMessage
 
 Re-exports: [NextMessage](../interfaces/common.nextmessage.md)
+
+___
+
+### PingMessage
+
+Re-exports: [PingMessage](../interfaces/common.pingmessage.md)
+
+___
+
+### PongMessage
+
+Re-exports: [PongMessage](../interfaces/common.pongmessage.md)
 
 ___
 

--- a/docs/modules/common.md
+++ b/docs/modules/common.md
@@ -16,6 +16,8 @@
 - [Disposable](../interfaces/common.disposable.md)
 - [ErrorMessage](../interfaces/common.errormessage.md)
 - [NextMessage](../interfaces/common.nextmessage.md)
+- [PingMessage](../interfaces/common.pingmessage.md)
+- [PongMessage](../interfaces/common.pongmessage.md)
 - [Sink](../interfaces/common.sink.md)
 - [SubscribeMessage](../interfaces/common.subscribemessage.md)
 - [SubscribePayload](../interfaces/common.subscribepayload.md)
@@ -107,7 +109,7 @@ ___
 
 ### Message
 
-Ƭ **Message**<T\>: `T` extends [ConnectionAck](../enums/common.messagetype.md#connectionack) ? [ConnectionAckMessage](../interfaces/common.connectionackmessage.md) : `T` extends [ConnectionInit](../enums/common.messagetype.md#connectioninit) ? [ConnectionInitMessage](../interfaces/common.connectioninitmessage.md) : `T` extends [Subscribe](../enums/common.messagetype.md#subscribe) ? [SubscribeMessage](../interfaces/common.subscribemessage.md) : `T` extends [Next](../enums/common.messagetype.md#next) ? [NextMessage](../interfaces/common.nextmessage.md) : `T` extends [Error](../enums/common.messagetype.md#error) ? [ErrorMessage](../interfaces/common.errormessage.md) : `T` extends [Complete](../enums/common.messagetype.md#complete) ? [CompleteMessage](../interfaces/common.completemessage.md) : `never`
+Ƭ **Message**<T\>: `T` extends [ConnectionAck](../enums/common.messagetype.md#connectionack) ? [ConnectionAckMessage](../interfaces/common.connectionackmessage.md) : `T` extends [ConnectionInit](../enums/common.messagetype.md#connectioninit) ? [ConnectionInitMessage](../interfaces/common.connectioninitmessage.md) : `T` extends [Ping](../enums/common.messagetype.md#ping) ? [PingMessage](../interfaces/common.pingmessage.md) : `T` extends [Pong](../enums/common.messagetype.md#pong) ? [PongMessage](../interfaces/common.pongmessage.md) : `T` extends [Subscribe](../enums/common.messagetype.md#subscribe) ? [SubscribeMessage](../interfaces/common.subscribemessage.md) : `T` extends [Next](../enums/common.messagetype.md#next) ? [NextMessage](../interfaces/common.nextmessage.md) : `T` extends [Error](../enums/common.messagetype.md#error) ? [ErrorMessage](../interfaces/common.errormessage.md) : `T` extends [Complete](../enums/common.messagetype.md#complete) ? [CompleteMessage](../interfaces/common.completemessage.md) : `never`
 
 #### Type parameters
 
@@ -127,7 +129,7 @@ ___
 
 ### isMessage
 
-▸ **isMessage**(`val`): val is ConnectionInitMessage \| ConnectionAckMessage \| SubscribeMessage \| NextMessage \| ErrorMessage \| CompleteMessage
+▸ **isMessage**(`val`): val is ConnectionInitMessage \| ConnectionAckMessage \| PingMessage \| PongMessage \| SubscribeMessage \| NextMessage \| ErrorMessage \| CompleteMessage
 
 Checks if the provided value is a message.
 
@@ -139,7 +141,7 @@ Checks if the provided value is a message.
 
 #### Returns
 
-val is ConnectionInitMessage \| ConnectionAckMessage \| SubscribeMessage \| NextMessage \| ErrorMessage \| CompleteMessage
+val is ConnectionInitMessage \| ConnectionAckMessage \| PingMessage \| PongMessage \| SubscribeMessage \| NextMessage \| ErrorMessage \| CompleteMessage
 
 ___
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,8 +76,8 @@ export type EventConnectingListener = () => void;
  * bundling DOM typings because the client can run in Node env too,
  * you should assert the websocket type during implementation.
  *
- * Second argument indicates whether the ping was received from the server.
- * If `false`, then the ping was sent by the client.
+ * Second argument communicates whether the ping was received from the server.
+ * If `false`, the ping was sent by the client.
  *
  * @category Client
  */
@@ -88,8 +88,8 @@ export type EventPingListener = (socket: unknown, received: boolean) => void;
  * bundling DOM typings because the client can run in Node env too,
  * you should assert the websocket type during implementation.
  *
- * Second argument indicates whether the pong was received from the server.
- * If `false`, then the pong was sent by the client.
+ * Second argument communicates whether the pong was received from the server.
+ * If `false`, the pong was sent by the client.
  *
  * @category Client
  */

--- a/src/client.ts
+++ b/src/client.ts
@@ -490,6 +490,7 @@ export function createClient(options: ClientOptions): Client {
                   replacer,
                 ),
               );
+              enqueuePing(); // enqueue ping (noop if disabled)
             } catch (err) {
               socket.close(
                 4400,
@@ -525,7 +526,6 @@ export function createClient(options: ClientOptions): Client {
               emitter.emit('connected', socket, message.payload); // connected = socket opened + acknowledged
               retrying = false; // future lazy connects are not retries
               retries = 0; // reset the retries on connect
-              enqueuePing(); // enqueue ping (noop if disabled)
               connected([
                 socket,
                 new Promise<void>((_, closed) =>

--- a/src/client.ts
+++ b/src/client.ts
@@ -492,7 +492,7 @@ export function createClient(options: ClientOptions): Client {
                   socket.send(stringifyMessage({ type: MessageType.Ping }));
                   emitter.emit('ping', false);
                 }
-              }, 30_000); // TODO-db-210608 customize timeout
+              }, keepAlive);
             }
           }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -64,6 +64,9 @@ export enum MessageType {
   ConnectionInit = 'connection_init', // Client -> Server
   ConnectionAck = 'connection_ack', // Server -> Client
 
+  Ping = 'ping', // bidirectional
+  Pong = 'pong', /// bidirectional
+
   Subscribe = 'subscribe', // Client -> Server
   Next = 'next', // Server -> Client
   Error = 'error', // Server -> Client
@@ -80,6 +83,16 @@ export interface ConnectionInitMessage {
 export interface ConnectionAckMessage {
   readonly type: MessageType.ConnectionAck;
   readonly payload?: Record<string, unknown>;
+}
+
+/** @category Common */
+export interface PingMessage {
+  readonly type: MessageType.Ping;
+}
+
+/** @category Common */
+export interface PongMessage {
+  readonly type: MessageType.Pong;
 }
 
 /** @category Common */
@@ -122,6 +135,10 @@ export type Message<T extends MessageType = MessageType> =
   T extends MessageType.ConnectionAck
     ? ConnectionAckMessage
     : T extends MessageType.ConnectionInit
+    ? PingMessage
+    : T extends MessageType.Ping
+    ? PongMessage
+    : T extends MessageType.Pong
     ? ConnectionInitMessage
     : T extends MessageType.Subscribe
     ? SubscribeMessage
@@ -160,6 +177,10 @@ export function isMessage(val: unknown): val is Message {
           val.payload === undefined ||
           isObject(val.payload)
         );
+      case MessageType.Ping:
+      case MessageType.Pong:
+        // ping and pong types are simply valid
+        return true;
       case MessageType.Subscribe:
         return (
           hasOwnStringProperty(val, 'id') &&

--- a/src/common.ts
+++ b/src/common.ts
@@ -135,11 +135,11 @@ export type Message<T extends MessageType = MessageType> =
   T extends MessageType.ConnectionAck
     ? ConnectionAckMessage
     : T extends MessageType.ConnectionInit
-    ? PingMessage
-    : T extends MessageType.Ping
-    ? PongMessage
-    : T extends MessageType.Pong
     ? ConnectionInitMessage
+    : T extends MessageType.Ping
+    ? PingMessage
+    : T extends MessageType.Pong
+    ? PongMessage
     : T extends MessageType.Subscribe
     ? SubscribeMessage
     : T extends MessageType.Next

--- a/src/server.ts
+++ b/src/server.ts
@@ -585,6 +585,14 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
             ctx.acknowledged = true;
             return;
           }
+          case MessageType.Ping: {
+            if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');
+            await socket.send(stringifyMessage({ type: MessageType.Pong }));
+            return;
+          }
+          case MessageType.Pong:
+            if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');
+            return;
           case MessageType.Subscribe: {
             if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -586,12 +586,10 @@ export function makeServer<E = unknown>(options: ServerOptions<E>): Server<E> {
             return;
           }
           case MessageType.Ping: {
-            if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');
             await socket.send(stringifyMessage({ type: MessageType.Pong }));
             return;
           }
           case MessageType.Pong:
-            if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');
             return;
           case MessageType.Subscribe: {
             if (!ctx.acknowledged) return socket.close(4401, 'Unauthorized');

--- a/src/tests/client.ts
+++ b/src/tests/client.ts
@@ -5,7 +5,7 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import { createClient, Client, EventListener } from '../client';
-import { SubscribePayload } from '../common';
+import { MessageType, stringifyMessage, SubscribePayload } from '../common';
 import { startWSTServer as startTServer, waitForDone } from './utils';
 
 // simulate browser environment for easier client testing
@@ -400,6 +400,84 @@ it(
     });
   }),
 );
+
+describe('ping/pong', () => {
+  it('should respond with a pong to a ping', async () => {
+    expect.assertions(1);
+
+    const { url, waitForConnect, waitForClient, waitForClientClose } =
+      await startTServer();
+
+    createClient({
+      url,
+      lazy: false,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    await waitForConnect();
+
+    await waitForClient((client) => {
+      client.send(stringifyMessage({ type: MessageType.Ping }));
+      client.onMessage((data) => {
+        expect(data).toBe('{"type":"pong"}');
+      });
+    });
+
+    await waitForClientClose(() => {
+      fail("Shouldn't have closed");
+    }, 20);
+  });
+
+  it('should not react to a pong', async () => {
+    const { url, waitForConnect, waitForClient, waitForClientClose } =
+      await startTServer();
+
+    createClient({
+      url,
+      lazy: false,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    await waitForConnect();
+
+    await waitForClient((client) => {
+      client.send(stringifyMessage({ type: MessageType.Pong }));
+      client.onMessage(() => {
+        fail("Shouldn't have received a message");
+      });
+    });
+
+    await waitForClientClose(() => {
+      fail("Shouldn't have closed");
+    }, 20);
+  });
+
+  it(
+    'should ping the server after the keepAlive timeout',
+    waitForDone(async (done) => {
+      const { url, waitForConnect, waitForClient } = await startTServer();
+
+      createClient({
+        url,
+        lazy: false,
+        retryAttempts: 0,
+        onNonLazyError: noop,
+        keepAlive: 20,
+      });
+
+      await waitForConnect();
+
+      await waitForClient((client) => {
+        client.onMessage((data) => {
+          expect(data).toBe('{"type":"ping"}');
+          done();
+        });
+      });
+    }),
+  );
+});
 
 describe('query operation', () => {
   it('should execute the query, "next" the result and then complete', async () => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -643,6 +643,46 @@ describe('Connect', () => {
   });
 });
 
+describe('Ping/Pong', () => {
+  it('should respond with a pong to a ping', async () => {
+    const { url } = await startTServer();
+
+    const client = await createTClient(url);
+
+    client.ws.send(
+      stringifyMessage({
+        type: MessageType.Ping,
+      }),
+    );
+
+    await client.waitForMessage(({ data }) => {
+      expect(parseMessage(data)).toEqual({
+        type: MessageType.Pong,
+      });
+    });
+  });
+
+  it('should not react to a pong', async () => {
+    const { url } = await startTServer();
+
+    const client = await createTClient(url);
+
+    client.ws.send(
+      stringifyMessage({
+        type: MessageType.Pong,
+      }),
+    );
+
+    await client.waitForMessage(() => {
+      fail('Shouldt have received a message');
+    }, 20);
+
+    await client.waitForClose(() => {
+      fail('Shouldt have closed');
+    }, 20);
+  });
+});
+
 describe('Subscribe', () => {
   it('should close the socket on request if connection is not acknowledged', async () => {
     const { url } = await startTServer();

--- a/src/tests/utils/tservers.ts
+++ b/src/tests/utils/tservers.ts
@@ -31,6 +31,7 @@ afterEach(async () => {
 });
 
 export interface TServerClient {
+  send(data: string): void;
   onMessage(cb: (message: string) => void): () => void;
   close(code?: number, data?: string): void;
 }
@@ -176,6 +177,7 @@ export async function startWSTServer(
 
   function toClient(socket: ws): TServerClient {
     return {
+      send: (data) => socket.send(data),
       onMessage: (cb) => {
         socket.on('message', cb);
         return () => socket.off('message', cb);
@@ -435,6 +437,7 @@ export async function startFastifyWSTServer(
 
   function toClient(socket: ws): TServerClient {
     return {
+      send: (data) => socket.send(data),
       onMessage: (cb) => {
         socket.on('message', cb);
         return () => socket.off('message', cb);


### PR DESCRIPTION
Closes #117

Introduces bidirectional ping/pong messages both in the Protocol and in the implementation. Server will respond with a pong to a ping, the same way a client would.

A simple recipe showcasing a client that times out if no pong is received and measures latency, looks like this:
```js
import { createClient } from 'graphql-ws';

let activeSocket,
  timedOut,
  pingSentAt = 0,
  latency = 0;
createClient({
  url: 'ws://i.time.out:4000/and-measure/latency',
  keepAlive: 10_000, // ping server every 10 seconds
  on: {
    connected: (socket) => (activeSocket = socket),
    ping: (received) => {
      if (!received /* sent */) {
        pingSentAt = Date.now();
        timedOut = setTimeout(() => {
          if (activeSocket.readyState === WebSocket.OPEN)
            activeSocket.close(4408, 'Request Timeout');
        }, 5_000); // wait 5 seconds for the pong and then close the connection
      }
    },
    pong: (received) => {
      if (received) {
        latency = Date.now() - pingSentAt;
        clearTimeout(timedOut); // pong is received, clear connection close timeout
      }
    },
  },
});
```

### Breaking change
This is considered a breaking change because of the introduction of new message types in the GraphQL over WebSocket Protocol. Because of the strictness, the Protocol requires instant connection termination whenever an invalid message is identified; meaning, all previous implementations will fail when receiving the new subprotocol ping/pong messages.

Do note that this influences mostly the client. The server still relies on [WebSocket transport level Ping and Pongs](https://developer.mozilla.org/en-US/docs/Web/API/wss_API/Writing_ws_servers#Pings_and_Pongs_The_Heartbeat_of_wss); however, since the ping/pong messages are bidirectional, you're free to implement them manually on the server too - the client will respond accordingly.

**Beware,** to ease the transition, the client will NOT ping the server by default _(and the default will probably stay because of server side keep-alive logic)_. Please make sure to upgrade your stack in order to support the new message types.