### PR TITLE
feat(client): Add `connectionAckWaitTimeout` option

### DIFF
--- a/docs/enums/common.CloseCode.md
+++ b/docs/enums/common.CloseCode.md
@@ -11,6 +11,7 @@
 ### Enumeration members
 
 - [BadRequest](common.CloseCode.md#badrequest)
+- [ConnectionAcknowledgementTimeout](common.CloseCode.md#connectionacknowledgementtimeout)
 - [ConnectionInitialisationTimeout](common.CloseCode.md#connectioninitialisationtimeout)
 - [Forbidden](common.CloseCode.md#forbidden)
 - [InternalServerError](common.CloseCode.md#internalservererror)
@@ -24,6 +25,12 @@
 ### BadRequest
 
 • **BadRequest** = `4400`
+
+___
+
+### ConnectionAcknowledgementTimeout
+
+• **ConnectionAcknowledgementTimeout** = `4418`
 
 ___
 

--- a/docs/enums/common.CloseCode.md
+++ b/docs/enums/common.CloseCode.md
@@ -30,7 +30,7 @@ ___
 
 ### ConnectionAcknowledgementTimeout
 
-• **ConnectionAcknowledgementTimeout** = `4418`
+• **ConnectionAcknowledgementTimeout** = `4504`
 
 ___
 

--- a/docs/interfaces/client.ClientOptions.md
+++ b/docs/interfaces/client.ClientOptions.md
@@ -10,6 +10,7 @@ Configuration used for the GraphQL over WebSocket client.
 
 ### Properties
 
+- [connectionAckWaitTimeout](client.ClientOptions.md#connectionackwaittimeout)
 - [connectionParams](client.ClientOptions.md#connectionparams)
 - [disablePong](client.ClientOptions.md#disablepong)
 - [jsonMessageReplacer](client.ClientOptions.md#jsonmessagereplacer)
@@ -30,6 +31,24 @@ Configuration used for the GraphQL over WebSocket client.
 - [retryWait](client.ClientOptions.md#retrywait)
 
 ## Properties
+
+### connectionAckWaitTimeout
+
+• `Optional` **connectionAckWaitTimeout**: `number`
+
+The amount of time for which the client will wait
+for `ConnectionAck` message.
+
+Set the value to `Infinity`, `''`, `0`, `null` or `undefined` to skip waiting.
+
+If the wait timeout has passed and the server
+has not responded with `ConnectionAck` message,
+the client will terminate the socket by
+dispatching a close event `4418: Connection acknowledgement timeout`
+
+**`default`** 0
+
+___
 
 ### connectionParams
 

--- a/src/__tests__/utils/tservers.ts
+++ b/src/__tests__/utils/tservers.ts
@@ -56,7 +56,7 @@ export interface TServer {
 
 type Dispose = (beNice?: boolean) => Promise<void>;
 
-async function getAvailablePort() {
+export async function getAvailablePort() {
   const httpServer = http.createServer();
 
   let tried = 0;

--- a/src/__tests__/utils/tservers.ts
+++ b/src/__tests__/utils/tservers.ts
@@ -56,7 +56,7 @@ export interface TServer {
 
 type Dispose = (beNice?: boolean) => Promise<void>;
 
-export async function getAvailablePort() {
+async function getAvailablePort() {
   const httpServer = http.createServer();
 
   let tried = 0;

--- a/src/common.ts
+++ b/src/common.ts
@@ -33,6 +33,7 @@ export enum CloseCode {
   Forbidden = 4403,
   SubprotocolNotAcceptable = 4406,
   ConnectionInitialisationTimeout = 4408,
+  ConnectionAcknowledgementTimeout = 4418,
   /** Subscriber distinction is very important */
   SubscriberAlreadyExists = 4409,
   TooManyInitialisationRequests = 4429,

--- a/src/common.ts
+++ b/src/common.ts
@@ -33,7 +33,7 @@ export enum CloseCode {
   Forbidden = 4403,
   SubprotocolNotAcceptable = 4406,
   ConnectionInitialisationTimeout = 4408,
-  ConnectionAcknowledgementTimeout = 4418,
+  ConnectionAcknowledgementTimeout = 4504,
   /** Subscriber distinction is very important */
   SubscriberAlreadyExists = 4409,
   TooManyInitialisationRequests = 4429,


### PR DESCRIPTION
On the server side exists a `connectionInitWaitTimeout` that would close the connection if no init is received but it doesn't exist the other way around. It could happen that the socket connects to an instance that is overloaded or shutting down and is not responding to messages or at least super slowly. In that case, the client should also timeout and try to reconnect and retry connection initialisation.

I added the same logic there's on the sevrer side but with a `connectionAckWaitTimeout` parameter. A 0/Infinity/null/empty value will not trigger the timeout. A positive number value will trigger a timeout that will close the socket with a specific error code and message. The timeout clears upon receiving the connection ack itself  Defaults to 0 to prevent breaking changes.