### PR TITLE
fix: reorder types in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,30 +33,30 @@
   "browser": "umd/graphql-ws.js",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "require": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./lib/index.d.ts",
       "browser": "./umd/graphql-ws.js"
     },
     "./lib/use/ws": {
+      "types": "./lib/use/ws.d.ts",
       "require": "./lib/use/ws.js",
-      "import": "./lib/use/ws.mjs",
-      "types": "./lib/use/ws.d.ts"
+      "import": "./lib/use/ws.mjs"
     },
     "./lib/use/uWebSockets": {
+      "types": "./lib/use/uWebSockets.d.ts",
       "require": "./lib/use/uWebSockets.js",
-      "import": "./lib/use/uWebSockets.mjs",
-      "types": "./lib/use/uWebSockets.d.ts"
+      "import": "./lib/use/uWebSockets.mjs"
     },
     "./lib/use/@fastify/websocket": {
+      "types": "./lib/use/@fastify/websocket.d.ts",
       "require": "./lib/use/@fastify/websocket.js",
-      "import": "./lib/use/@fastify/websocket.mjs",
-      "types": "./lib/use/@fastify/websocket.d.ts"
+      "import": "./lib/use/@fastify/websocket.mjs"
     },
     "./lib/use/fastify-websocket": {
+      "types": "./lib/use/fastify-websocket.d.ts",
       "require": "./lib/use/fastify-websocket.js",
-      "import": "./lib/use/fastify-websocket.mjs",
-      "types": "./lib/use/fastify-websocket.d.ts"
+      "import": "./lib/use/fastify-websocket.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "node": ">=10"
   },
   "packageManager": "yarn@3.2.3",
+  "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "module": "lib/index.mjs",
   "browser": "umd/graphql-ws.js",
@@ -60,7 +61,6 @@
     },
     "./package.json": "./package.json"
   },
-  "types": "lib/index.d.ts",
   "files": [
     "lib",
     "umd",


### PR DESCRIPTION
This puts the `"types"` of every export in `package.json` to be the first entry in the object. Without this, import resolution fails in `nodenext` and `node16` modes.