### PR TITLE
fix: ensure asyncIterator call return() when fail at calling next()

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -824,6 +824,10 @@ export function makeServer<
               // completed the subscription, he doesnt need to be reminded
               await emit.complete(id in ctx.subscriptions);
             } finally {
+              // before delete the subcription, we should call `return` of asyncIterator to prevent it from hanging
+              const sub = ctx.subscriptions[id];
+              if (isAsyncGenerator(sub)) await sub.return(undefined);
+
               // whatever happens to the subscription, we finally want to get rid of the reservation
               delete ctx.subscriptions[id];
             }


### PR DESCRIPTION
This calls `.return()` of asyncIterator before remove it from `subscriptions`.

After https://github.com/microsoft/TypeScript/pull/51297, error at `iterator.next()` in `for await (... of iterator)` statement does not call `iterator.return()`. This can cause asyncIterator not to be cleared and hang.