### PR TITLE
feat: Allow null payloads in messages

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -37,7 +37,7 @@ If the server receives more than one `ConnectionInit` message at any given time,
 ```typescript
 interface ConnectionInitMessage {
   type: 'connection_init';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -52,7 +52,7 @@ The server can use the optional `payload` field to transfer additional details a
 ```typescript
 interface ConnectionAckMessage {
   type: 'connection_ack';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -73,7 +73,7 @@ The optional `payload` field can be used to transfer additional details about th
 ```typescript
 interface PingMessage {
   type: 'ping';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 
@@ -90,7 +90,7 @@ The optional `payload` field can be used to transfer additional details about th
 ```typescript
 interface PongMessage {
   type: 'pong';
-  payload?: Record<string, unknown>;
+  payload?: Record<string, unknown> | null;
 }
 ```
 

--- a/src/__tests__/__snapshots__/common.ts.snap
+++ b/src/__tests__/__snapshots__/common.ts.snap
@@ -56,13 +56,11 @@ exports[`should report invalid message {"type":""} with descriptive error 1`] = 
 
 exports[`should report invalid message {"type":"complete"} with descriptive error 1`] = `""complete" message expects the 'id' property to be a string, but got undefined"`;
 
-exports[`should report invalid message {"type":"connection_ack","payload":""} with descriptive error 1`] = `""connection_ack" message expects the 'payload' property to be an object or missing, but got """`;
+exports[`should report invalid message {"type":"connection_ack","payload":""} with descriptive error 1`] = `""connection_ack" message expects the 'payload' property to be an object or nullish or missing, but got """`;
 
-exports[`should report invalid message {"type":"connection_init","payload":""} with descriptive error 1`] = `""connection_init" message expects the 'payload' property to be an object or missing, but got """`;
+exports[`should report invalid message {"type":"connection_init","payload":""} with descriptive error 1`] = `""connection_init" message expects the 'payload' property to be an object or nullish or missing, but got """`;
 
-exports[`should report invalid message {"type":"connection_init","payload":0} with descriptive error 1`] = `""connection_init" message expects the 'payload' property to be an object or missing, but got "0""`;
-
-exports[`should report invalid message {"type":"connection_init"} with descriptive error 1`] = `""connection_init" message expects the 'payload' property to be an object or missing, but got "undefined""`;
+exports[`should report invalid message {"type":"connection_init","payload":0} with descriptive error 1`] = `""connection_init" message expects the 'payload' property to be an object or nullish or missing, but got "0""`;
 
 exports[`should report invalid message {"type":"error"} with descriptive error 1`] = `""error" message expects the 'id' property to be a string, but got undefined"`;
 
@@ -72,9 +70,7 @@ exports[`should report invalid message {"type":"next"} with descriptive error 2`
 
 exports[`should report invalid message {"type":"nuxt"} with descriptive error 1`] = `"Invalid message 'type' property "nuxt""`;
 
-exports[`should report invalid message {"type":"ping","payload":0} with descriptive error 1`] = `""ping" message expects the 'payload' property to be an object or missing, but got "0""`;
-
-exports[`should report invalid message {"type":"pong"} with descriptive error 1`] = `""pong" message expects the 'payload' property to be an object or missing, but got "undefined""`;
+exports[`should report invalid message {"type":"ping","payload":0} with descriptive error 1`] = `""ping" message expects the 'payload' property to be an object or nullish or missing, but got "0""`;
 
 exports[`should report invalid message {"type":"subscribe"} with descriptive error 1`] = `""subscribe" message expects the 'id' property to be a string, but got undefined"`;
 

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -37,20 +37,12 @@ it.each([
     payload: 0,
   },
   {
-    type: MessageType.ConnectionInit,
-    payload: undefined,
-  },
-  {
     type: MessageType.ConnectionAck,
     payload: '',
   },
   {
     type: MessageType.Ping,
     payload: 0,
-  },
-  {
-    type: MessageType.Pong,
-    payload: undefined,
   },
 
   // invalid subscribe message
@@ -220,11 +212,19 @@ it.each([
     payload: {},
   },
   {
+    type: MessageType.ConnectionInit,
+    payload: null,
+  },
+  {
     type: MessageType.ConnectionAck,
   },
   {
     type: MessageType.ConnectionAck,
     payload: {},
+  },
+  {
+    type: MessageType.ConnectionAck,
+    payload: null,
   },
   {
     type: MessageType.Ping,
@@ -234,11 +234,19 @@ it.each([
     payload: {},
   },
   {
+    type: MessageType.Ping,
+    payload: null,
+  },
+  {
     type: MessageType.Pong,
   },
   {
     type: MessageType.Pong,
     payload: {},
+  },
+  {
+    type: MessageType.Pong,
+    payload: null,
   },
 
   // valid subscribe message

--- a/src/common.ts
+++ b/src/common.ts
@@ -228,9 +228,9 @@ export function validateMessage(val: unknown): Message {
     case MessageType.ConnectionAck:
     case MessageType.Ping:
     case MessageType.Pong: {
-      if ('payload' in val && !isObject(val.payload)) {
+      if (val.payload != null && !isObject(val.payload)) {
         throw new Error(
-          `"${val.type}" message expects the 'payload' property to be an object or missing, but got "${val.payload}"`,
+          `"${val.type}" message expects the 'payload' property to be an object or nullish or missing, but got "${val.payload}"`,
         );
       }
 


### PR DESCRIPTION
Closes #455
Related https://github.com/graphql/graphql-over-http/pull/243

Original thinking was to support keeping the message size small by completely omitting the payload if nullish. But, that was an unnecessary limiting optimization.

Furthermore, allowing null values also keeps the spec more in line with the GraphQL over HTTP spec.

> Specifying `null` in JSON (or equivalent values in other formats) as values for optional request parameters is equivalent to not specifying them at all.

[_GraphQL over HTTP spec_](https://graphql.github.io/graphql-over-http/draft/)