### PR TITLE
docs(recipe): update urql example to fit on latest version

### DIFF
--- a/website/src/pages/recipes.mdx
+++ b/website/src/pages/recipes.mdx
@@ -195,8 +195,13 @@ export const network = Network.create(fetchOrSubscribe, fetchOrSubscribe);
 ## Client usage with [urql](https://formidable.com/open-source/urql/)
 
 ```ts
-import { createClient, defaultExchanges, subscriptionExchange } from 'urql';
-import { createClient as createWSClient } from 'graphql-ws';
+import {
+  createClient,
+  cacheExchange,
+  fetchExchange,
+  subscriptionExchange,
+} from 'urql';
+import { createClient as createWSClient, SubscribePayload } from 'graphql-ws';
 
 const wsClient = createWSClient({
   url: 'ws://its.urql:4000/graphql',
@@ -205,12 +210,16 @@ const wsClient = createWSClient({
 const client = createClient({
   url: '/graphql',
   exchanges: [
-    ...defaultExchanges,
+    cacheExchange,
+    fetchExchange,
     subscriptionExchange({
       forwardSubscription(operation) {
         return {
           subscribe: (sink) => {
-            const dispose = wsClient.subscribe(operation, sink);
+            const dispose = wsClient.subscribe(
+              operation as SubscribePayload,
+              sink,
+            );
             return {
               unsubscribe: dispose,
             };


### PR DESCRIPTION
Hi, I updated the example for using `urql`, because the current example is not valid for the latest `urql` package.

* move `import { defaultExchanges }` to `import { cacheExchange, fetchExchange }`
  * `defaultExchanges` are removed in the latest package. ([CHANGELOG link](https://github.com/urql-graphql/urql/blob/35657e771633be43b850f0a1f7fdbac94b075dd7/packages/core/CHANGELOG.md#major-changes))

* Type assertion for client.subscribe
  * The argument for `forwardSubscription` returned non-nullable string `query` in previous packages, ([related link](https://github.com/urql-graphql/urql/blob/%40urql/vue%401.0.4/packages/core/src/exchanges/subscription.ts#L43))
  * But it does return a nullable `query` now. ([related link #1](https://github.com/urql-graphql/urql/blob/main/packages/core/src/exchanges/subscription.ts#L68), [related link #2](https://github.com/urql-graphql/urql/blob/main/packages/core/src/internal/fetchOptions.ts#L11))

  * So it have to be asserted as a non-nullable value before using it in `graphql-ws`.


Any better changes/comments are welcomed. (I am quite a newbie for this package)

Thanks,
spacebarley