### PR TITLE
feat(client): Async iterator for subscriptions

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -14,6 +14,7 @@ import {
 } from '../common';
 import { startRawServer, startWSTServer as startTServer } from './utils';
 import { ExecutionResult } from 'graphql';
+import { pong } from './fixtures/simple';
 
 // silence console.error calls for nicer tests overview
 const consoleError = console.error;
@@ -2322,5 +2323,263 @@ describe('events', () => {
 
     // opened and connected should be called 6 times (3 times connected, 2 times disconnected)
     expect(expected).toBeCalledTimes(6);
+  });
+});
+
+describe('iterate', () => {
+  it('should iterate a single result query', async () => {
+    const { url } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const iterator = client.iterate({
+      query: '{ getValue }',
+    });
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "getValue": "value",
+          },
+        },
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should iterate over subscription events', async () => {
+    const { url } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const iterator = client.iterate({
+      query: 'subscription { greetings }',
+    });
+
+    // Hi
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Bonjour
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Hola
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Ciao
+    await expect(iterator.next()).resolves.toBeDefined();
+    // Zdravo
+    await expect(iterator.next()).resolves.toBeDefined();
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should report execution errors to iterator', async () => {
+    const { url } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const iterator = client.iterate({
+      query: 'subscription { throwing }',
+    });
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "errors": [
+            {
+              "locations": [
+                {
+                  "column": 16,
+                  "line": 1,
+                },
+              ],
+              "message": "Kaboom!",
+              "path": [
+                "throwing",
+              ],
+            },
+          ],
+        },
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+  });
+
+  it('should throw in iterator connection errors', async () => {
+    const { url, ...server } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+
+    pong(pingKey);
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "ping": "pong",
+          },
+        },
+      }
+    `);
+
+    await server.dispose(false);
+
+    await expect(iterator.next()).rejects.toEqual(
+      // forceful close
+      expect.objectContaining({
+        code: 1006,
+        reason: '',
+      }),
+    );
+  });
+
+  it('should complete subscription when iterator loop breaks', async () => {
+    const { url, ...server } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+    iterator.return = jest.fn(iterator.return);
+
+    setTimeout(() => pong(pingKey), 0);
+
+    for await (const val of iterator) {
+      expect(val).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "ping": "pong",
+          },
+        }
+      `);
+      break;
+    }
+
+    expect(iterator.return).toHaveBeenCalled();
+
+    await server.waitForClientClose();
+  });
+
+  it('should complete subscription when iterator loop throws', async () => {
+    const { url, ...server } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+    iterator.return = jest.fn(iterator.return);
+
+    setTimeout(() => pong(pingKey), 0);
+
+    await expect(async () => {
+      for await (const val of iterator) {
+        expect(val).toMatchInlineSnapshot(`
+          {
+            "data": {
+              "ping": "pong",
+            },
+          }
+        `);
+        throw new Error(':)');
+      }
+    }).rejects.toBeDefined();
+
+    expect(iterator.return).toHaveBeenCalled();
+
+    await server.waitForClientClose();
+  });
+
+  it('should complete subscription when calling return directly on iterator', async () => {
+    const { url, ...server } = await startTServer();
+
+    const client = createClient({
+      url,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const pingKey = Math.random().toString();
+    const iterator = client.iterate({
+      query: `subscription { ping(key: "${pingKey}") }`,
+    });
+
+    pong(pingKey);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": false,
+        "value": {
+          "data": {
+            "ping": "pong",
+          },
+        },
+      }
+    `);
+
+    await expect(iterator.return?.()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+
+    await expect(iterator.next()).resolves.toMatchInlineSnapshot(`
+      {
+        "done": true,
+        "value": undefined,
+      }
+    `);
+
+    await server.waitForClientClose();
   });
 });

--- a/src/__tests__/fixtures/simple.ts
+++ b/src/__tests__/fixtures/simple.ts
@@ -100,6 +100,12 @@ export const schemaConfig: GraphQLSchemaConfig = {
           };
         },
       },
+      throwing: {
+        type: new GraphQLNonNull(GraphQLString),
+        subscribe: async function () {
+          throw new Error('Kaboom!');
+        },
+      },
     },
   }),
 };

--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -186,46 +186,25 @@ const client = createClient({
 
 // query
 (async () => {
-  const result = await new Promise((resolve, reject) => {
-    let result;
-    client.subscribe(
-      {
-        query: '{ hello }',
-      },
-      {
-        next: (data) => (result = data),
-        error: reject,
-        complete: () => resolve(result),
-      },
-    );
+  const query = client.iterate({
+    query: '{ hello }',
   });
 
-  expect(result).toEqual({ hello: 'Hello World!' });
+  const { value } = await query.next();
+  expect(value).toEqual({ hello: 'world' });
 })();
 
 // subscription
 (async () => {
-  const onNext = () => {
-    /* handle incoming values */
-  };
-
-  let unsubscribe = () => {
-    /* complete the subscription */
-  };
-
-  await new Promise((resolve, reject) => {
-    unsubscribe = client.subscribe(
-      {
-        query: 'subscription { greetings }',
-      },
-      {
-        next: onNext,
-        error: reject,
-        complete: resolve,
-      },
-    );
+  const subscription = client.iterate({
+    query: 'subscription { greetings }',
   });
 
-  expect(onNext).toBeCalledTimes(5); // we say "Hi" in 5 languages
+  for await (const event of subscription) {
+    expect(event).toEqual({ greetings: 'Hi' });
+
+    // complete a running subscription by breaking the iterator loop
+    break;
+  }
 })();
 ```

--- a/website/src/pages/recipes.mdx
+++ b/website/src/pages/recipes.mdx
@@ -11,25 +11,15 @@ const client = createClient({
   url: 'ws://hey.there:4000/graphql',
 });
 
-async function execute<T>(payload: SubscribePayload) {
-  return new Promise<T>((resolve, reject) => {
-    let result: T;
-    client.subscribe<T>(payload, {
-      next: (data) => (result = data),
-      error: reject,
-      complete: () => resolve(result),
-    });
-  });
-}
-
-// use
 (async () => {
+  const query = client.iterate({
+    query: '{ hello }',
+  });
+
   try {
-    const result = await execute({
-      query: '{ hello }',
-    });
+    const { value } = await query.next();
+    // next = value = { data: { hello: 'Hello World!' } }
     // complete
-    // next = result = { data: { hello: 'Hello World!' } }
   } catch (err) {
     // error
   }
@@ -45,60 +35,15 @@ const client = createClient({
   url: 'ws://iterators.ftw:4000/graphql',
 });
 
-function subscribe<T>(payload: SubscribePayload): AsyncGenerator<T> {
-  let deferred: {
-    resolve: (done: boolean) => void;
-    reject: (err: unknown) => void;
-  } | null = null;
-  const pending: T[] = [];
-  let throwMe: unknown = null,
-    done = false;
-  const dispose = client.subscribe<T>(payload, {
-    next: (data) => {
-      pending.push(data);
-      deferred?.resolve(false);
-    },
-    error: (err) => {
-      throwMe = err;
-      deferred?.reject(throwMe);
-    },
-    complete: () => {
-      done = true;
-      deferred?.resolve(true);
-    },
-  });
-  return {
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-    async next() {
-      if (done) return { done: true, value: undefined };
-      if (throwMe) throw throwMe;
-      if (pending.length) return { value: pending.shift()! };
-      return (await new Promise<boolean>(
-        (resolve, reject) => (deferred = { resolve, reject }),
-      ))
-        ? { done: true, value: undefined }
-        : { value: pending.shift()! };
-    },
-    async throw(err) {
-      throw err;
-    },
-    async return() {
-      dispose();
-      return { done: true, value: undefined };
-    },
-  };
-}
-
 (async () => {
-  const subscription = subscribe({
+  const subscription = client.iterate({
     query: 'subscription { greetings }',
   });
-  // subscription.return() to dispose
+  // "subscription.return()" to dispose
 
   for await (const result of subscription) {
     // next = result = { data: { greetings: 5x } }
+    // "break" to dispose
   }
   // complete
 })();


### PR DESCRIPTION
The `iterate` method on the client allows async iteration over the subscription events.

```js
import { createClient } from 'graphql-ws';

const client = createClient({
  url: 'ws://localhost:4000/graphql',
});

// query
(async () => {
  const query = client.iterate({
    query: '{ hello }',
  });

  const { value } = await query.next();
  expect(value).toEqual({ hello: 'world' });
})();

// subscription
(async () => {
  const subscription = client.iterate({
    query: 'subscription { greetings }',
  });

  for await (const event of subscription) {
    expect(event).toEqual({ greetings: 'Hi' });

    // complete a running subscription by breaking the iterator loop
    break;
  }
})();
```

### TODO

- [ ] ~Overload `subscribe` method~ https://github.com/microsoft/TypeScript/issues/54354