### PR TITLE
docs(bun): Fix Bun Import

### DIFF
--- a/website/src/pages/get-started.mdx
+++ b/website/src/pages/get-started.mdx
@@ -118,7 +118,7 @@ fastify.listen(4000, (err) => {
 #### With [Bun](https://bun.sh)
 
 ```ts
-import { makeHandler, handleProtocols } from 'graphql-ws/lib/use/lib/bun';
+import { makeHandler, handleProtocols } from 'graphql-ws/lib/use/bun';
 import { schema } from './previous-step';
 
 Bun.serve({


### PR DESCRIPTION
## Description 📝 

- Fixes a typo of the Bun import in the Getting Started docs
- Changes `graphql-ws/lib/use/lib/bun` to `graphql-ws/lib/use/bun` ✏️ 