### PR TITLE
Fix close event code for BadGateway

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1695,6 +1695,7 @@ describe('reconnecting', () => {
     console.warn = warn;
     await testCloseCode(CloseCode.InternalServerError);
     await testCloseCode(CloseCode.InternalClientError);
+    await testCloseCode(CloseCode.BadGateway);
     await testCloseCode(CloseCode.BadRequest);
     await testCloseCode(CloseCode.BadResponse);
     await testCloseCode(CloseCode.Unauthorized);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1088,7 +1088,7 @@ function isFatalInternalCloseCode(code: number): boolean {
       1005, // No Status Received
       1012, // Service Restart
       1013, // Try Again Later
-      1013, // Bad Gateway
+      1014, // Bad Gateway
     ].includes(code)
   )
     return false;

--- a/src/common.ts
+++ b/src/common.ts
@@ -29,6 +29,7 @@ export const DEPRECATED_GRAPHQL_WS_PROTOCOL = 'graphql-ws';
 export enum CloseCode {
   InternalServerError = 4500,
   InternalClientError = 4005,
+  BadGateway = 1014,
   BadRequest = 4400,
   BadResponse = 4004,
   /** Tried subscribing before connect ack */


### PR DESCRIPTION
This corrects the close event code for BadGateway from 1013 to 1014 https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code#value 

This error is considered non fatal and users should be able to retry.