### PR TITLE
docs(protocol): clarify id field is not optional

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -11,10 +11,9 @@ The WebSocket sub-protocol for this specification is: `graphql-transport-ws`.
 
 Messages are represented through the JSON structure and are stringified before being sent over the network. They are bidirectional, meaning both the server and the client must conform to the specified message structure.
 
-**All** messages contain the `type` field outlining the action this message describes. Depending on the type, the message can contain two more _optional_ fields:
+**All** messages contain the `type` field outlining the action this message describes. Depending on the type, the message can contain the _optional_ field `payload` holding the extra "payload" information to go with the specific message type.
 
-- `id` used for uniquely identifying server responses and connecting them with the client's requests
-- `payload` holding the extra "payload" information to go with the specific message type
+Messages corresponding to operations contain the `id` field used for uniquely identifying server responses and connecting them with the client's requests.
 
 Multiple operations identified with separate IDs can be active at any time and their messages can be interleaved on the connection.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -11,7 +11,7 @@ The WebSocket sub-protocol for this specification is: `graphql-transport-ws`.
 
 Messages are represented through the JSON structure and are stringified before being sent over the network. They are bidirectional, meaning both the server and the client must conform to the specified message structure.
 
-**All** messages contain the `type` field outlining the action this message describes. Depending on the type, the message can contain the _optional_ field `payload` holding the extra "payload" information to go with the specific message type.
+**All** messages contain the `type` field outlining the action this message describes.
 
 Messages corresponding to operations contain the `id` field used for uniquely identifying server responses and connecting them with the client's requests.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -13,7 +13,7 @@ Messages are represented through the JSON structure and are stringified before b
 
 **All** messages contain the `type` field outlining the action this message describes.
 
-Messages corresponding to operations contain the `id` field used for uniquely identifying server responses and connecting them with the client's requests.
+Messages corresponding to operations must contain the `id` field used for uniquely identifying server responses and connecting them with the client's requests.
 
 Multiple operations identified with separate IDs can be active at any time and their messages can be interleaved on the connection.
 


### PR DESCRIPTION
This PR aims to clarify the section of the protocol which states that the `id` field is optional even though this field is either required or not present as per the type definitions. (Also discussed in [#340](https://github.com/enisdenjo/graphql-ws/discussions/340#discussioncomment-7703620))

At first, I wanted to mention specifically that `Subscribe`, `Next`, `Error`, and `Complete` message types needs to have the `id` field. However, the sentence that needs to be clarified is in the "Communication" section which comes before the explanation of the message types. So, I used the term "Messages corresponding to operations" to refer to those message types. 

Though, I am not sure if this sentence sounds clear enough. I am happy to accept any improvements for wording.