### PR TITLE
Expand Error Handling Test Coverage

### DIFF
--- a/src/__tests__/__snapshots__/client.ts.snap
+++ b/src/__tests__/__snapshots__/client.ts.snap
@@ -1,5 +1,249 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`failable queries should iterate successfully when nothing is thrown: {} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`failable queries should iterate successfully when resolve throws: {"resolve":true} 1`] = `
+[
+  {
+    "result": {
+      "data": null,
+      "errors": [
+        {
+          "locations": [
+            {
+              "column": 28,
+              "line": 1,
+            },
+          ],
+          "message": "Kaboom!",
+          "path": [
+            "throwingFrom",
+          ],
+        },
+      ],
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should iterate successfully when nothing is thrown: {} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "2",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "3",
+      },
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should iterate successfully when resolve throws: {"resolveStep":1} 1`] = `
+[
+  {
+    "result": {
+      "data": null,
+      "errors": [
+        {
+          "locations": [
+            {
+              "column": 9,
+              "line": 2,
+            },
+          ],
+          "message": "Kaboom from resolve step 1!",
+          "path": [
+            "throwingFrom",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "2",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "3",
+      },
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should iterate successfully when resolve throws: {"resolveStep":2} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": null,
+      "errors": [
+        {
+          "locations": [
+            {
+              "column": 9,
+              "line": 2,
+            },
+          ],
+          "message": "Kaboom from resolve step 2!",
+          "path": [
+            "throwingFrom",
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "3",
+      },
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should iterate successfully when resolve throws: {"resolveStep":3} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "2",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": null,
+      "errors": [
+        {
+          "locations": [
+            {
+              "column": 9,
+              "line": 2,
+            },
+          ],
+          "message": "Kaboom from resolve step 3!",
+          "path": [
+            "throwingFrom",
+          ],
+        },
+      ],
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should iterate successfully when subscribe throws before returning a generator: {"beforeGenerator":true} 1`] = `
+[
+  {
+    "result": {
+      "errors": [
+        {
+          "locations": [
+            {
+              "column": 9,
+              "line": 2,
+            },
+          ],
+          "message": "Kaboom from before generator!",
+          "path": [
+            "throwingFrom",
+          ],
+        },
+      ],
+    },
+  },
+]
+`;
+
+exports[`failable subscriptions should throw an error when the generator throws from next: {"generatorStep":1} 1`] = `
+[
+  {
+    "failure": "4500 Kaboom from generator step 1! (was clean: true)",
+  },
+]
+`;
+
+exports[`failable subscriptions should throw an error when the generator throws from next: {"generatorStep":2} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+  {
+    "failure": "4500 Kaboom from generator step 2! (was clean: true)",
+  },
+]
+`;
+
+exports[`failable subscriptions should throw an error when the generator throws from next: {"generatorStep":3} 1`] = `
+[
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "1",
+      },
+    },
+  },
+  {
+    "result": {
+      "data": {
+        "throwingFrom": "2",
+      },
+    },
+  },
+  {
+    "failure": "4500 Kaboom from generator step 3! (was clean: true)",
+  },
+]
+`;
+
 exports[`should report close error even if complete message followed 1`] = `""error" message expects the 'payload' property to be an array of GraphQL errors, but got "malformed""`;
 
 exports[`should report close error even if complete message followed 2`] = `""error" message expects the 'payload' property to be an array of GraphQL errors, but got "malformed""`;

--- a/src/__tests__/__snapshots__/server.ts.snap
+++ b/src/__tests__/__snapshots__/server.ts.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Failable queries should complete with errors when resolve throws: {"resolve":true} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"errors":[{"message":"Kaboom!","locations":[{"line":2,"column":15}],"path":["throwingFrom"]}],"data":null}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable queries should complete without errors when nothing is thrown: {} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable subscriptions should close the socket when the generator throws from next: {"generatorStep":1} 1`] = `
+[
+  {
+    "code": 4500,
+    "reason": "Kaboom from generator step 1!",
+    "wasClean": true,
+  },
+]
+`;
+
+exports[`Failable subscriptions should close the socket when the generator throws from next: {"generatorStep":2} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  {
+    "code": 4500,
+    "reason": "Kaboom from generator step 2!",
+    "wasClean": true,
+  },
+]
+`;
+
+exports[`Failable subscriptions should close the socket when the generator throws from next: {"generatorStep":3} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"2"}}}",
+  {
+    "code": 4500,
+    "reason": "Kaboom from generator step 3!",
+    "wasClean": true,
+  },
+]
+`;
+
+exports[`Failable subscriptions should complete with errors when resolve throws: {"resolveStep":1} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"errors":[{"message":"Kaboom from resolve step 1!","locations":[{"line":2,"column":15}],"path":["throwingFrom"]}],"data":null}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"2"}}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"3"}}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable subscriptions should complete with errors when resolve throws: {"resolveStep":2} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  "{"id":"1","type":"next","payload":{"errors":[{"message":"Kaboom from resolve step 2!","locations":[{"line":2,"column":15}],"path":["throwingFrom"]}],"data":null}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"3"}}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable subscriptions should complete with errors when resolve throws: {"resolveStep":3} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"2"}}}",
+  "{"id":"1","type":"next","payload":{"errors":[{"message":"Kaboom from resolve step 3!","locations":[{"line":2,"column":15}],"path":["throwingFrom"]}],"data":null}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable subscriptions should complete with errors when subscribe throws before returning a generator: {"beforeGenerator":true} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"errors":[{"message":"Kaboom from before generator!","locations":[{"line":2,"column":15}],"path":["throwingFrom"]}]}}",
+  "{"id":"1","type":"complete"}",
+]
+`;
+
+exports[`Failable subscriptions should complete without errors when nothing is thrown: {} 1`] = `
+[
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"1"}}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"2"}}}",
+  "{"id":"1","type":"next","payload":{"data":{"throwingFrom":"3"}}}",
+  "{"id":"1","type":"complete"}",
+]
+`;

--- a/src/__tests__/server.ts
+++ b/src/__tests__/server.ts
@@ -888,6 +888,7 @@ describe('Subscribe', () => {
       });
     });
 
+    await client.waitForMessage();
     await client.waitForClose(() => {
       fail('Shouldt have closed');
     }, 30);
@@ -1089,6 +1090,7 @@ describe('Subscribe', () => {
       });
     }
 
+    await client.waitForMessage();
     await client.waitForClose(() => {
       fail('Shouldt have closed');
     }, 30);

--- a/src/__tests__/server.ts
+++ b/src/__tests__/server.ts
@@ -573,7 +573,7 @@ describe('Connect', () => {
     });
 
     await client.waitForClose(() => {
-      fail('Shouldnt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -743,11 +743,11 @@ describe('Ping/Pong', () => {
     );
 
     await client.waitForMessage(() => {
-      fail('Shouldt have received a message');
+      fail("Shouldn't have received a message");
     }, 20);
 
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 20);
   });
 
@@ -757,7 +757,7 @@ describe('Ping/Pong', () => {
     const closed = makeServer({}).opened(
       {
         protocol: GRAPHQL_TRANSPORT_WS_PROTOCOL,
-        send: () => fail('Shouldnt have responded to a ping'),
+        send: () => fail("Shouldn't have responded to a ping"),
         close: () => {
           /**/
         },
@@ -771,7 +771,7 @@ describe('Ping/Pong', () => {
             done();
           });
         },
-        onPong: () => fail('Nothing shouldve ponged'),
+        onPong: () => fail("Nothing should've ponged"),
       },
       {},
     );
@@ -790,7 +790,7 @@ describe('Ping/Pong', () => {
         onMessage: (cb) => {
           cb(stringifyMessage({ type: MessageType.Pong, payload }));
         },
-        onPing: () => fail('Nothing shouldve pinged'),
+        onPing: () => fail("Nothing should've pinged"),
         onPong: (pyld) => {
           setImmediate(() => {
             expect(pyld).toEqual(payload);
@@ -890,7 +890,7 @@ describe('Subscribe', () => {
 
     await client.waitForMessage();
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -937,7 +937,7 @@ describe('Subscribe', () => {
     });
 
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -993,7 +993,7 @@ describe('Subscribe', () => {
     });
 
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -1039,7 +1039,7 @@ describe('Subscribe', () => {
     });
 
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -1092,7 +1092,7 @@ describe('Subscribe', () => {
 
     await client.waitForMessage();
     await client.waitForClose(() => {
-      fail('Shouldt have closed');
+      fail("Shouldn't have closed");
     }, 30);
   });
 
@@ -1335,7 +1335,7 @@ describe('Subscribe', () => {
     });
 
     await client.waitForClose(() => {
-      fail('Shouldnt close because of GraphQL errors');
+      fail("Shouldn't close because of GraphQL errors");
     }, 30);
   });
 


### PR DESCRIPTION
This PR adds tests covering how errors from the `subscribe` and `resolve` functions associated with a field definition are handled. The commit messages go into the details in each commit, but as a simplified overview, the test GraphQL schema has been updated to include a query and a subscription that allows the caller to control whether an error is thrown from various parts of their implementations. Using that, the client and server tests have been updated to compare the results of various permutations of those operations against snapshots of the current behaviour.

This PR makes no changes outside of test code; I've added these tests to both learn about and document the existing behaviour rather than to fix a specific bug.