### PR TITLE
fix(server): Close code and reason are optional for `close`

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -447,7 +447,7 @@ export interface WebSocket {
    * The returned promise is used to control the graceful
    * closure.
    */
-  close(code: number, reason: string): Promise<void> | void;
+  close(code?: number, reason?: string): Promise<void> | void;
   /**
    * Called when message is received. The library requires the data
    * to be a `string`.


### PR DESCRIPTION
Follow-up to https://github.com/enisdenjo/graphql-ws/commit/6ae6e6f4e392975ad786cf61e4947fd57f5cf56c, which missed the `close` method