### PR TITLE
allow to provide a third additional argument for a custom WebSocket implementation

### DIFF
--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -2595,3 +2595,29 @@ describe('iterate', () => {
     await server.waitForClientClose();
   });
 });
+
+it('should pass additional options when provided', async () => {
+  const server = await startTServer();
+
+  const expectedOptions = {};
+
+  class CustomWebSocket extends WebSocket {
+    constructor(url: string, protocol: string, options: object) {
+      expect(options).toBe(expectedOptions);
+      super(url, protocol);
+    }
+  }
+
+  let client = createClient({
+    url: server.url,
+    retryAttempts: 0,
+    onNonLazyError: noop,
+    lazy: false,
+    webSocketImpl: CustomWebSocket,
+    webSocketOpts: expectedOptions,
+  });
+
+  await server.waitForConnect();
+  await client.dispose();
+  expect.assertions(1);
+});


### PR DESCRIPTION
This PR aims to allow for more customization of the WebSocket class used by the client to establish connection.

When use on Node, one will probably want to use `ws` package as the `WebSocket` implementation. But currently, the API doesn't allow to pass any additional options to the `WebSocket` constructor.

This PR adds an option `webSocketOpts` that will be passed as a third argument to `WebSocket` constructor when a custom implementation has been provided.