### PR TITLE
Fix WS types, current ones are broken

### DIFF
--- a/src/use/ws.ts
+++ b/src/use/ws.ts
@@ -1,5 +1,5 @@
 import type * as http from 'http';
-import type * as ws from 'ws';
+import type { WebSocket, WebSocketServer } from 'ws';
 import { handleProtocols, makeServer, ServerOptions } from '../server';
 import {
   DEPRECATED_GRAPHQL_WS_PROTOCOL,
@@ -10,8 +10,7 @@ import {
 import { limitCloseReason } from '../utils';
 
 // for nicer documentation
-type WebSocket = typeof ws.prototype;
-type WebSocketServer = ws.Server;
+export type { WebSocket, WebSocketServer };
 
 /**
  * The extra that will be put in the `Context`.


### PR DESCRIPTION
WS library has changed how types are exported and graphql-ws is breaking builds if type checking for libraries is active:

```
node_modules/graphql-ws/lib/use/ws.d.ts(5,28): error TS2339: Property 'prototype' does not exist on type 'typeof import("/ptp/node_modules/@types/ws/index")'.

node_modules/graphql-ws/lib/use/ws.d.ts(6,27): error TS2694: Namespace '"/ptp/node_modules/@types/ws/index"' has no exported member 'Server'.
```

I have just properly imported types so we can use the library without problems. 

Let me know if you need anything else from me. Hope to see it released soon! 
