### PR TITLE
fix(server): onError should return GraphQLFormattedError

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import { GraphQLError, ExecutionResult } from 'graphql';
+import { GraphQLFormattedError, ExecutionResult } from 'graphql';
 import {
   isObject,
   areGraphQLErrors,
@@ -54,7 +54,7 @@ export interface NextMessage {
 export interface ErrorMessage {
   readonly id: string;
   readonly type: MessageType.Error;
-  readonly payload: readonly GraphQLError[];
+  readonly payload: readonly GraphQLFormattedError[];
 }
 
 export interface CompleteMessage {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,8 @@ import {
   GraphQLError,
   SubscriptionArgs,
   ExecutionResult,
+  GraphQLFormattedError,
+  formatError,
 } from 'graphql';
 import { Disposable } from './types';
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL } from './protocol';
@@ -247,7 +249,10 @@ export interface ServerOptions {
     ctx: Context,
     message: ErrorMessage,
     errors: readonly GraphQLError[],
-  ) => Promise<readonly GraphQLError[] | void> | readonly GraphQLError[] | void;
+  ) =>
+    | Promise<readonly GraphQLFormattedError[] | void>
+    | readonly GraphQLFormattedError[]
+    | void;
   /**
    * Executed after an operation has emitted a result right before
    * that result has been sent to the client. Results from both
@@ -524,7 +529,7 @@ export function createServer(
                 let errorMessage: ErrorMessage = {
                   id: message.id,
                   type: MessageType.Error,
-                  payload: errors,
+                  payload: errors.map(formatError),
                 };
                 if (onError) {
                   const maybeErrors = await onError(ctx, errorMessage, errors);


### PR DESCRIPTION
The types sent over the wire should be _formatted_ types - specifically errors should be piped through `formatError` and the types shouldn't imply that they're `instanceof GraphQLError` - they're just data.

> [!WARNING]
> This is a breaking change _if_ anyone's `onError` callback is relying on `instanceof GraphQLError` checks (seems extremely unlikely?), but otherwise it should be safe because `GraphQLError` conforms to `GraphQLFormattedError`.

> [!TIP]
> I don't actually care about `formatError` being called in core (feel free to revert that), I just care that the type of the `onError` hook allows a formatted error be returned for consistency, and that the payload type should not imply the errors are `instanceof GraphQLError`.

> [!NOTE]
> The payloads that send `ExecutionResult` should also be sending `FormattedExecutionResult` but that seemed like a larger change so I didn't make it.
