### PR TITLE
fix(common): Fix the `FormattedExecutionResult.errors` type

### DIFF
--- a/.changeset/eleven-bears-warn.md
+++ b/.changeset/eleven-bears-warn.md
@@ -1,0 +1,5 @@
+---
+'graphql-ws': patch
+---
+
+FormattedExecutionResult errors field returns GraphQLFormattedError

--- a/src/common.ts
+++ b/src/common.ts
@@ -163,7 +163,7 @@ export interface FormattedExecutionResult<
   Data = Record<string, unknown>,
   Extensions = Record<string, unknown>,
 > {
-  errors?: ReadonlyArray<FormattedExecutionResult> | undefined;
+  errors?: ReadonlyArray<GraphQLFormattedError> | undefined;
   data?: Data | null | undefined;
   hasNext?: boolean | undefined;
   extensions?: Extensions | undefined;


### PR DESCRIPTION
https://github.com/enisdenjo/graphql-ws/releases/tag/v6.0.0 introduced a `FormattedExecutionResult`, however, its `errors` type seems to be incorrect as it's set to `ReadonlyArray<FormattedExecutionResult>` rather than `ReadonlyArray<GraphQLFormattedError>`:

```ts
/** @category Common */
export interface FormattedExecutionResult<
  Data = Record<string, unknown>,
  Extensions = Record<string, unknown>,
> {
  errors?: ReadonlyArray<FormattedExecutionResult> | undefined;
  data?: Data | null | undefined;
  hasNext?: boolean | undefined;
  extensions?: Extensions | undefined;
}
```

This is remediated by this PR.