### PR TITLE
WIP: allow custom protocols to be included in the opening connection

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -226,6 +226,18 @@ export interface ClientOptions<
    */
   connectionParams?: P | (() => Promise<P> | P);
   /**
+   * Optional protocols, passed through to the WebSocket constructor that will be part of 
+   * the `Sec-WebSocket-Protocol` header sent to the server. As browser WebSocket connections
+   * do not allow setting arbitary headings this can be used by server implementations to send
+   * arbitary data for example Authentication headers, especially when it's desired to happen 
+   * prior to a WebSocket conncetion being answer
+   * 
+   * If the option is a function, it will be called on every WebSocket connection attempt.
+   * Returning a promise is supported too and the connecting phase will stall until it
+   * resolves with the URL.
+   */
+  additionalProtocols?: string[] | (() => Promise<string[]> | string[]);
+  /**
    * Controls when should the connection be established.
    *
    * - `false`: Establish a connection immediately. Use `onNonLazyError` to handle errors.
@@ -456,6 +468,7 @@ export function createClient<
   const {
     url,
     connectionParams,
+    additionalProtocols,
     lazy = true,
     onNonLazyError = console.error,
     lazyCloseTimeout: lazyCloseTimeoutMs = 0,
@@ -619,7 +632,12 @@ export function createClient<
           emitter.emit('connecting', retrying);
           const socket = new WebSocketImpl(
             typeof url === 'function' ? await url() : url,
-            GRAPHQL_TRANSPORT_WS_PROTOCOL,
+            [GRAPHQL_TRANSPORT_WS_PROTOCOL, ...(
+              additionalProtocols ? 
+                typeof additionalProtocols === 'function' 
+                  ? await additionalProtocols() 
+                  : additionalProtocols :
+                  [])],
           );
 
           let connectionAckTimeout: ReturnType<typeof setTimeout>,


### PR DESCRIPTION
I am looking to introduce the ability to define custom protocols in the websocket opening so that servers can use this for authentication or other custom data.

This is because that under Browser WebSocket APIs you cannot include custom headers in the HTTP connection that gets upgraded (e.g. `Authorization`)

GraphQL-ws library already suggests two authentication points. One is by encoding a token in the URL `wss://myserver.example.com/graphql?token=<>` and the other is by utilising the `ConnectionInit` and opening phase of the protocol.

The use of URL paramaters for authentication is generally discouraged due to the risk of leaking into proxy, network or system logs. ConnectionInit would generally preferred but is not available in all implementations.

Here is a documented use of a major project using subprotocols to enable connection-time authentication for generic websocket connections: https://quarkus.io/guides/websockets-next-reference#bearer-token-authentication

As it happens, my colleague is also attempting to add support into Quarkus to support authentication at ConnectionInit within the context of graphql-ws https://github.com/quarkusio/quarkus/pull/49643/

This PR is not yet ready for formal review and is missing tests, but I'm just looking for a comment on if this feature would be allowed.