### PR TITLE
Remove uWebSockets.js from peer dependencies in package.json

### DIFF
--- a/.changeset/fast-onions-tickle.md
+++ b/.changeset/fast-onions-tickle.md
@@ -1,0 +1,7 @@
+---
+'graphql-ws': patch
+---
+
+Remove uWebSockets.js from peer dependencies in package.json
+
+It does not exist on NPM anymore and could lead to weird behavior when installing dependencies with `npm`. Nothing else changes, using `graphql-ws` with uWebSockets.js still works.

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup and install
-        uses: the-guild-org/shared-config/setup@f46b872d8427e68bec27c3e7eb2dd25f29cc91f0
+        uses: the-guild-org/shared-config/setup@v1
         with:
           node-version-file: .node-version
           working-directory: website

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup and install
-        uses: the-guild-org/shared-config/setup@v1
+        uses: the-guild-org/shared-config/setup@f46b872d8427e68bec27c3e7eb2dd25f29cc91f0
         with:
           node-version-file: .node-version
           working-directory: website

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "@fastify/websocket": "^10 || ^11",
     "crossws": "~0.3",
     "graphql": "^15.10.1 || ^16",
-    "uWebSockets.js": "^20",
     "ws": "^8"
   },
   "peerDependenciesMeta": {
@@ -142,9 +141,6 @@
       "optional": true
     },
     "crossws": {
-      "optional": true
-    },
-    "uWebSockets.js": {
       "optional": true
     },
     "ws": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2700,14 +2700,11 @@ __metadata:
     "@fastify/websocket": ^10 || ^11
     crossws: ~0.3
     graphql: ^15.10.1 || ^16
-    uWebSockets.js: ^20
     ws: ^8
   peerDependenciesMeta:
     "@fastify/websocket":
       optional: true
     crossws:
-      optional: true
-    uWebSockets.js:
       optional: true
     ws:
       optional: true


### PR DESCRIPTION
It does not exist on NPM anymore and could lead to weird behavior when installing dependencies with `npm`. Nothing else changes, using `graphql-ws` with uWebSockets.js still works.

It existed on npm [before](https://web.archive.org/web/20250805162701/https://www.npmjs.com/package/uWebSockets.js), npm [deleted it recently](https://www.npmjs.com/package/uWebSockets.js).

<img width="1149" height="795" alt="image" src="https://github.com/user-attachments/assets/c2aee827-5dbb-421d-b156-acf8a7f24fde" />