### PR TITLE
fix(client): don't remove an unrelated listener when disposing of an already-removed listener

### DIFF
--- a/.changeset/afraid-pandas-repeat.md
+++ b/.changeset/afraid-pandas-repeat.md
@@ -1,0 +1,7 @@
+---
+'graphql-ws': patch
+---
+
+Disposing of a client event listener twice no longer removes an unrelated listener
+
+The unsubscribe function returned by `client.on` spliced at `indexOf(listener)` without checking for `-1`, so removing an already-removed listener would `splice(-1, 1)` and silently drop the most recently registered listener of the same event. This happens in practice without any double-dispose by the user: emits iterate over a copy of the listeners, so a one-shot internal listener that already unlistened itself during a nested emit (e.g. when `client.terminate()` is called from within a `closed`/`error` listener) is re-invoked from the copy and unlistens again, knocking out registered `closed`/`error` listeners.

--- a/src/client.ts
+++ b/src/client.ts
@@ -553,7 +553,15 @@ export function createClient<
         const l = listeners[event] as EventListener<E>[];
         l.push(listener);
         return () => {
-          l.splice(l.indexOf(listener), 1);
+          // the listener might have already been removed. removing it again
+          // would `splice(-1, 1)` and drop the last, unrelated, listener. this
+          // can happen because emits iterate over a copy of the listeners:
+          // a one-shot listener that already unlistened itself during a nested
+          // emit can be re-invoked (and unlisten again) from the copy
+          const i = l.indexOf(listener);
+          if (i > -1) {
+            l.splice(i, 1);
+          }
         };
       },
       emit<E extends Event>(event: E, ...args: Parameters<EventListener<E>>) {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -2450,6 +2450,95 @@ describe.concurrent('events', () => {
     // opened and connected should be called 6 times (3 times connected, 2 times disconnected)
     expect(expected).toHaveBeenCalledTimes(6);
   });
+
+  it('should not remove other listeners when disposing of the same listener twice', async ({
+    expect,
+  }) => {
+    const { url, waitForConnect, getClients } = await startTServer();
+
+    const client = createClient({
+      url,
+      lazy: false,
+      retryAttempts: 0,
+      onNonLazyError: noop,
+    });
+
+    const disposedListener = vitest.fn();
+    const dispose = client.on('closed', disposedListener);
+    const survivingListener = vitest.fn();
+    client.on('closed', survivingListener);
+
+    // disposing of the same listener twice must not affect other listeners
+    dispose();
+    dispose();
+
+    await waitForConnect();
+
+    const { resolve: closed, promise: waitForClosed } = createDeferred();
+    client.on('closed', () => closed());
+    for (const client of getClients()) {
+      client.close(4321);
+    }
+    await waitForClosed;
+
+    expect(disposedListener).not.toBeCalled();
+    expect(survivingListener).toBeCalled();
+
+    await client.dispose();
+  });
+
+  it('should not lose listeners when a closed listener terminates the client', async ({
+    expect,
+  }) => {
+    const { url, waitForConnect, getClients } = await startTServer();
+
+    const client = createClient({
+      // a url function suspends the connect routine, deferring the internal
+      // listener registration behind the user listeners registered right
+      // after `createClient` (like clients resolving the url asynchronously)
+      url: () => url,
+      lazy: false,
+      retryAttempts: 5,
+      retryWait: async () => {
+        // retry immediately
+      },
+      onNonLazyError: noop,
+    });
+
+    client.on('closed', (event) => {
+      // terminating from within a listener nests another `closed` emit
+      // inside the running one (guarding against the artificial
+      // TerminatedCloseEvent to avoid recursing forever)
+      if (!(event instanceof TerminatedCloseEvent)) {
+        client.terminate();
+      }
+    });
+    const observer = vitest.fn();
+    client.on('closed', observer);
+
+    await waitForConnect();
+    for (const client of getClients()) {
+      client.close(4321);
+    }
+
+    // the terminated client reconnects (4499 is retryable)
+    await waitForConnect();
+    const callsAfterFirstClose = observer.mock.calls.length;
+    expect(callsAfterFirstClose).toBeGreaterThan(0);
+
+    const { resolve: closedAgain, promise: waitForClosedAgain } =
+      createDeferred();
+    client.on('closed', () => closedAgain());
+    for (const client of getClients()) {
+      client.close(4321);
+    }
+    await waitForClosedAgain;
+
+    // the observer must still be registered and receive the second round of closed events
+    expect(observer.mock.calls.length).toBeGreaterThan(callsAfterFirstClose);
+
+    await client.dispose();
+  });
 });
 
 describe.concurrent('iterate', () => {


### PR DESCRIPTION
The unsubscribe function returned by `client.on` removes the listener with `l.splice(l.indexOf(listener), 1)`. When the listener has already been removed, `indexOf` yields `-1` and `splice(-1, 1)` removes the last listener of the same
event instead of doing nothing.

This corrupts the listener registry without any double-dispose by the user: emits iterate over a copy of the listeners, so when `client.terminate()` is called from within a `closed` listener, the nested synthetic `closed` emit makes the internal one-shot `errorOrClosed` listeners unlisten themselves — and the still-running outer emit re-invokes them from its stale copy, so they unlisten again and knock registered `closed`/`error` listeners out of the registry. From that point on the client silently stops reporting `closed`/`error` events.

We hit this in production: a client that terminates on a 4401 close (to reconnect with a fresh token) lost its `closed` listener this way, leaving the app blind to later disconnects for the rest of a call.

Fixed by guarding the unsubscribe with an `indexOf` check so that removing an already-removed listener is a no-op. Added two regression tests that fail on master.