### PR TITLE
feat(server): Add `parse` option for custom GraphQL parsing

### DIFF
--- a/.changeset/gold-students-roll.md
+++ b/.changeset/gold-students-roll.md
@@ -1,0 +1,5 @@
+---
+'graphql-ws': minor
+---
+
+Add `parse` option for custom GraphQL parsing

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,11 +11,11 @@ import {
   GraphQLError,
   execute as graphqlExecute,
   GraphQLFormattedError,
+  parse as graphqlParse,
   GraphQLSchema,
   subscribe as graphqlSubscribe,
   validate as graphqlValidate,
   OperationTypeNode,
-  parse,
   versionInfo,
 } from 'graphql';
 import {
@@ -145,6 +145,16 @@ export interface ServerOptions<
           NonNullable<ExecutionArgs['rootValue']>
         >;
       };
+  /**
+   * A custom GraphQL parse function allowing you to apply your own
+   * parsing logic.
+   *
+   * Will not be used when implementing a custom `onSubscribe`.
+   *
+   * Throwing an error from within this function will close the socket
+   * with the `Error` message in the close event reason.
+   */
+  parse?: undefined | typeof graphqlParse;
   /**
    * A custom GraphQL validate function allowing you to apply your
    * own validation rules.
@@ -561,6 +571,7 @@ export function makeServer<
     schema,
     context,
     roots,
+    parse,
     validate,
     execute,
     subscribe,
@@ -782,7 +793,7 @@ export function makeServer<
 
                 const args = {
                   operationName: payload.operationName,
-                  document: parse(payload.query),
+                  document: (parse ?? graphqlParse)(payload.query),
                   variableValues: payload.variables,
                 };
                 execArgs = {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -76,6 +76,42 @@ it('should use the schema resolved from a promise on subscribe', async ({
   await waitForComplete;
 });
 
+it('should use the provided parse function', async ({ expect }) => {
+  let didCallParse = false;
+  const { url } = await startTServer({
+    schema,
+    parse: (...args) => {
+      didCallParse = true;
+      return parse(...args);
+    },
+  });
+  const client = await createTClient(url, GRAPHQL_TRANSPORT_WS_PROTOCOL);
+  client.ws.send(
+    stringifyMessage<MessageType.ConnectionInit>({
+      type: MessageType.ConnectionInit,
+    }),
+  );
+  await client.waitForMessage(); // ack
+
+  client.ws.send(
+    stringifyMessage<MessageType.Subscribe>({
+      id: '1',
+      type: MessageType.Subscribe,
+      payload: {
+        query: '{ getValue }',
+      },
+    }),
+  );
+  await client.waitForMessage(({ data }) => {
+    expect(parseMessage(data)).toEqual({
+      id: '1',
+      type: MessageType.Next,
+      payload: { data: { getValue: 'value' } },
+    });
+  });
+  expect(didCallParse).toBeTruthy();
+});
+
 it('should use the provided validate function', async ({ expect }) => {
   const { url } = await startTServer({
     schema,


### PR DESCRIPTION
We allow swapping out `validate`, `execute`, etc, and should allow `parse` too. This is useful for caching, logging, and the like.